### PR TITLE
Update: Move `Message` to `openai4s.types`, add `Message` newtypes to `Chat` and `Response`, and reorganise tests

### DIFF
--- a/modules/openai4s-core/shared/src/main/scala-2/openai4s/request/Chat.scala
+++ b/modules/openai4s-core/shared/src/main/scala-2/openai4s/request/Chat.scala
@@ -1,15 +1,13 @@
 package openai4s.request
 
+import openai4s.types
 import cats.data.NonEmptyList
 import cats.{Eq, Show}
-import eu.timepit.refined.cats._
+import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.{NonNegDouble, PosInt}
-import eu.timepit.refined.types.string.NonEmptyString
-import extras.render.Render
-import extras.render.refined._
 import io.circe.generic.extras.Configuration
-import io.circe.refined._
-import io.circe.{Codec, Decoder, Encoder}
+import io.circe.refined.*
+import io.circe.{Decoder, Encoder}
 import io.estatico.newtype.macros.newtype
 import openai4s.types.Model
 
@@ -22,6 +20,7 @@ final case class Chat(
   temperature: Option[Chat.Temperature],
   maxTokens: Option[Chat.MaxTokens],
 )
+
 object Chat {
   implicit val chatConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
 
@@ -34,34 +33,20 @@ object Chat {
     io.circe.generic.extras.semiauto.deriveConfiguredEncoder[Chat].mapJson(_.deepDropNullValues)
   implicit val chatDecoder: Decoder[Chat] = io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 
-  final case class Message(role: Message.Role, content: Message.Content)
+  @newtype case class Message(value: types.Message)
+
   object Message {
-    implicit val messageCodec: Codec[Message] = io.circe.generic.extras.semiauto.deriveConfiguredCodec
-    @newtype case class Role(value: NonEmptyString)
-    object Role {
-      implicit val roleEq: Eq[Role] = deriving
+    implicit val messageEq: Eq[Message] = deriving
 
-      implicit val roleRender: Render[Role] = deriving
-      implicit val roleShow: Show[Role]     = deriving
+    implicit val messageShow: Show[Message] = deriving
 
-      implicit val roleEncoder: Encoder[Role] = deriving
-      implicit val roleDecoder: Decoder[Role] = deriving
-    }
-
-    @newtype case class Content(value: NonEmptyString)
-    object Content {
-      implicit val contentEq: Eq[Content] = deriving
-
-      implicit val contentRender: Render[Content] = deriving
-      implicit val contentShow: Show[Content]     = deriving
-
-      implicit val contentEncoder: Encoder[Content] = deriving
-      implicit val contentDecoder: Decoder[Content] = deriving
-    }
+    implicit val messageEncoder: Encoder[Message] = deriving
+    implicit val messageDecoder: Decoder[Message] = deriving
 
   }
 
   @newtype case class Temperature(value: NonNegDouble)
+
   object Temperature {
     implicit val temperatureEq: Eq[Temperature] = deriving
 
@@ -72,6 +57,7 @@ object Chat {
   }
 
   @newtype case class MaxTokens(value: PosInt)
+
   object MaxTokens {
     implicit val maxTokensEq: Eq[MaxTokens] = deriving
 

--- a/modules/openai4s-core/shared/src/main/scala-2/openai4s/response/Response.scala
+++ b/modules/openai4s-core/shared/src/main/scala-2/openai4s/response/Response.scala
@@ -1,13 +1,15 @@
 package openai4s.response
 
 import cats.{Eq, Show}
-import eu.timepit.refined.cats._
+import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.string.NonEmptyString
 import extras.render.Render
-import extras.render.refined._
-import io.circe.refined._
+import extras.render.refined.*
+import io.circe.generic.extras.Configuration
+import io.circe.refined.*
 import io.circe.{Codec, Decoder, Encoder}
 import io.estatico.newtype.macros.newtype
+import openai4s.types
 import openai4s.types.Model
 
 import java.time.Instant
@@ -25,11 +27,13 @@ final case class Response(
 )
 object Response {
 
+  implicit val responseConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
+
   implicit val responseEq: Eq[Response] = Eq.fromUniversalEquals
 
   implicit val responseShow: Show[Response] = cats.derived.semiauto.show
 
-  implicit val responseCodec: Codec[Response] = io.circe.generic.semiauto.deriveCodec
+  implicit val responseCodec: Codec[Response] = io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
   @newtype case class Id(value: NonEmptyString)
   object Id {
@@ -74,7 +78,7 @@ object Response {
 
     implicit val usageShow: Show[Usage] = cats.derived.semiauto.show
 
-    implicit val usageCodec: Codec[Usage] = io.circe.generic.semiauto.deriveCodec
+    implicit val usageCodec: Codec[Usage] = io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
     @newtype case class PromptTokens(value: Int)
     object PromptTokens {
@@ -117,37 +121,15 @@ object Response {
 
     implicit val choiceShow: Show[Choice] = cats.derived.semiauto.show
 
-    implicit val choiceCodec: Codec[Choice] = io.circe.generic.semiauto.deriveCodec
+    implicit val choiceCodec: Codec[Choice] = io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
-    @newtype case class Role(value: String)
-    object Role {
-      implicit val roleEq: Eq[Role] = deriving
-
-      implicit val roleShow: Show[Role]     = deriving
-      implicit val roleRender: Render[Role] = deriving
-
-      implicit val roleEncoder: Encoder[Role] = deriving
-      implicit val roleDecoder: Decoder[Role] = deriving
-    }
-
-    @newtype case class Content(value: String)
-    object Content {
-      implicit val contentEq: Eq[Content] = deriving
-
-      implicit val contentShow: Show[Content]     = deriving
-      implicit val contentRender: Render[Content] = deriving
-
-      implicit val contentEncoder: Encoder[Content] = deriving
-      implicit val contentDecoder: Decoder[Content] = deriving
-    }
-
-    final case class Message(role: Role, content: Content)
+    @newtype case class Message(value: types.Message)
     object Message {
-      implicit val messageEq: Eq[Message] = Eq.fromUniversalEquals
+      implicit val messageEq: Eq[Message] = deriving
 
-      implicit val messageShow: Show[Message] = cats.derived.semiauto.show[Message]
+      implicit val messageShow: Show[Message] = deriving
 
-      implicit val messageCodec: Codec[Message] = io.circe.generic.semiauto.deriveCodec
+      implicit val messageCodec: Codec[Message] = deriving
     }
 
     @newtype case class FinishReason(value: String)

--- a/modules/openai4s-core/shared/src/main/scala-2/openai4s/types/Message.scala
+++ b/modules/openai4s-core/shared/src/main/scala-2/openai4s/types/Message.scala
@@ -1,0 +1,50 @@
+package openai4s.types
+
+import cats.{Eq, Show}
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import extras.render.Render
+import extras.render.refined.*
+import io.circe.generic.extras.Configuration
+import io.circe.refined.*
+import io.circe.{Codec, Decoder, Encoder}
+import io.estatico.newtype.macros.newtype
+
+/** @author Kevin Lee
+  * @since 2023-03-24
+  */
+final case class Message(role: Message.Role, content: Message.Content)
+object Message {
+  implicit val messageConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
+
+  implicit val messageEq: Eq[Message] = Eq.fromUniversalEquals
+
+  implicit val messageShow: Show[Message] = cats.derived.semiauto.show
+
+  implicit val messageCodec: Codec[Message] = io.circe.generic.extras.semiauto.deriveConfiguredCodec
+
+  @newtype case class Role(value: NonEmptyString)
+
+  object Role {
+    implicit val roleEq: Eq[Role] = deriving
+
+    implicit val roleRender: Render[Role] = deriving
+    implicit val roleShow: Show[Role]     = deriving
+
+    implicit val roleEncoder: Encoder[Role] = deriving
+    implicit val roleDecoder: Decoder[Role] = deriving
+  }
+
+  @newtype case class Content(value: NonEmptyString)
+
+  object Content {
+    implicit val contentEq: Eq[Content] = deriving
+
+    implicit val contentRender: Render[Content] = deriving
+    implicit val contentShow: Show[Content]     = deriving
+
+    implicit val contentEncoder: Encoder[Content] = deriving
+    implicit val contentDecoder: Decoder[Content] = deriving
+  }
+
+}

--- a/modules/openai4s-core/shared/src/test/scala/openai4s/request/ChatSpec.scala
+++ b/modules/openai4s-core/shared/src/test/scala/openai4s/request/ChatSpec.scala
@@ -1,10 +1,10 @@
 package openai4s.request
 
 import extras.hedgehog.circe.RoundTripTester
-import extras.refinement.syntax.all._
-import extras.render.syntax._
-import hedgehog._
-import hedgehog.runner._
+import extras.refinement.syntax.all.*
+import extras.render.syntax.*
+import hedgehog.*
+import hedgehog.runner.*
 import io.circe.Json
 
 /** @author Kevin Lee
@@ -13,7 +13,7 @@ import io.circe.Json
 object ChatSpec extends Properties {
   override def tests: List[Prop] = List(
     property("round-trip test Chat", roundTripTestChat),
-    property("test decoding Chat", testDecodingChat),
+    property("test encoding Chat", testEncodingChat),
   )
 
   def roundTripTestChat: Property =
@@ -21,22 +21,22 @@ object ChatSpec extends Properties {
       chat <- Gens.genChat.log("chat")
     } yield RoundTripTester(chat).test()
 
-  def testDecodingChat: Property =
+  def testEncodingChat: Property =
     for {
       chat <- Gens.genChat.log("chat")
     } yield {
-      import io.circe.literal._
-      import io.circe.syntax._
+      import io.circe.literal.*
+      import io.circe.syntax.*
 
-      def messages(message: Chat.Message): Json =
+      def toJson(message: Chat.Message): Json =
         json"""{
-          "role": ${message.role.render},
-          "content": ${message.content.render}
+          "role": ${message.value.role.render},
+          "content": ${message.value.content.render}
         }"""
 
       val expected = json"""{
            "model": ${chat.model.render},
-           "messages": ${chat.messages.map(messages)},
+           "messages": ${chat.messages.map(toJson)},
            "temperature": ${chat.temperature.map(_.toValue)},
            "max_tokens": ${chat.maxTokens.map(_.toValue)}
          }""".deepDropNullValues

--- a/modules/openai4s-core/shared/src/test/scala/openai4s/request/Gens.scala
+++ b/modules/openai4s-core/shared/src/test/scala/openai4s/request/Gens.scala
@@ -2,37 +2,13 @@ package openai4s.request
 
 import cats.data.NonEmptyList
 import eu.timepit.refined.types.numeric.{NonNegDouble, PosInt}
-import eu.timepit.refined.types.string.NonEmptyString
-import hedgehog._
-import openai4s.types.Model
+import hedgehog.*
+import openai4s.types
 
 /** @author Kevin Lee
   * @since 2023-04-02
   */
 object Gens {
-
-  def genModel: Gen[Model] =
-    Gen.element1(
-      Model.gpt_4,
-      Model.gpt_4_0314,
-      Model.gpt_4_32k,
-      Model.gpt_4_32k_0314,
-      Model.gpt_3_5_Turbo,
-      Model.gpt_3_5_Turbo_0301,
-      Model.text_Davinci_003,
-      Model.text_Davinci_002,
-      Model.code_Davinci_002,
-    )
-
-  def genMessage: Gen[Chat.Message] =
-    for {
-      role    <- Gen
-                   .string(Gen.unicode, Range.linear(1, 10))
-                   .map(role => Chat.Message.Role(NonEmptyString.unsafeFrom(role)))
-      content <- Gen
-                   .string(Gen.unicode, Range.linear(1, 800))
-                   .map(content => Chat.Message.Content(NonEmptyString.unsafeFrom(content)))
-    } yield Chat.Message(role, content)
 
   def genTemperature: Gen[Chat.Temperature] =
     Gen.double(Range.linearFrac(0d, 200d)).map(d => Chat.Temperature(NonNegDouble.unsafeFrom(d)))
@@ -42,8 +18,8 @@ object Gens {
 
   def genChat: Gen[Chat] =
     for {
-      model       <- genModel
-      messages    <- genMessage.list(Range.linear(1, 10)).map(NonEmptyList.fromListUnsafe)
+      model    <- types.Gens.genModel
+      messages <- types.Gens.genMessage.map(Chat.Message(_)).list(Range.linear(1, 10)).map(NonEmptyList.fromListUnsafe)
       temperature <- genTemperature.option
       maxTokens   <- genMaxTokens.option
     } yield Chat(

--- a/modules/openai4s-core/shared/src/test/scala/openai4s/types/Gens.scala
+++ b/modules/openai4s-core/shared/src/test/scala/openai4s/types/Gens.scala
@@ -1,0 +1,40 @@
+package openai4s.types
+
+import eu.timepit.refined.types.string.NonEmptyString
+import hedgehog.{Gen, Range}
+
+/** @author Kevin Lee
+  * @since 2023-04-02
+  */
+object Gens {
+
+  def genModel: Gen[Model] =
+    Gen.element1(
+      Model.gpt_4,
+      Model.gpt_4_0314,
+      Model.gpt_4_32k,
+      Model.gpt_4_32k_0314,
+      Model.gpt_3_5_Turbo,
+      Model.gpt_3_5_Turbo_0301,
+      Model.text_Davinci_003,
+      Model.text_Davinci_002,
+      Model.code_Davinci_002,
+    )
+
+  def genRole: Gen[Message.Role] =
+    Gen
+      .string(Gen.unicode, Range.linear(1, 10))
+      .map(role => Message.Role(NonEmptyString.unsafeFrom(role)))
+
+  def genContent: Gen[Message.Content] =
+    Gen
+      .string(Gen.unicode, Range.linear(1, 800))
+      .map(content => Message.Content(NonEmptyString.unsafeFrom(content)))
+
+  def genMessage: Gen[Message] =
+    for {
+      role    <- genRole
+      content <- genContent
+    } yield Message(role, content)
+
+}


### PR DESCRIPTION
Update: Move `Message` to `openai4s.types`, add `Message` newtypes to `Chat` and `Response`, and reorganise tests