### PR TITLE
openai4s v0.1.0-alpha1

### DIFF
--- a/changelogs/0.1.0-alpha1.md
+++ b/changelogs/0.1.0-alpha1.md
@@ -1,0 +1,33 @@
+## [0.1.0-alpha1](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A%3C2023-06-25) - 2020-07-04
+
+## Done
+* Set up the project (#1)
+* Drop supporting Scala 2.12 (#20)
+* Add `api` sub-project and add `chat/completions` (#26)
+* Support Scala 3 (#29)
+  
+  Support Scala 3.2.2. There might be an issue with newtype and refined in Scala 3 as
+  * newtype doesn't support Scala 3
+  * Some refined features are broken in Scala 3 (e.g. macro for compile-time type check)
+* Add `completions.Text` (#34)
+  * https://platform.openai.com/docs/api-reference/completions#:~:text=prompt%20and%20parameters.-,Request%20body,-model
+* Add `completions.Response` (#37)
+  * https://platform.openai.com/docs/api-reference/completions/create#:~:text=%22%5Cn%22%0A%7D-,Response
+* Add `CompletionsApi` (#40)
+  ```scala
+  import openai4s.types.completions
+  
+  val completionsApi = CompletionsApi[F](completionsUri, apiKey, httpClient)
+  val text = completions.Text(
+    model = completions.Model.text_Davinci_003,
+    prompt = completions.Text.Prompt(NonEmptyString("What is tagless final?")).some,
+    maxTokens = completions.Text.MaxTokens(PosInt(2048)).some,
+    temperature = completions.Text.Temperature.unsafeFrom(0.2f).some,
+    topP = none,
+    n = none,
+    stream = none,
+    logprobs = none,
+    stop = none,
+  )
+  completionsApi.completions(text)
+  ```

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha1"


### PR DESCRIPTION
# openai4s v0.1.0-alpha1
## [0.1.0-alpha1](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A%3C2023-06-25) - 2020-07-04

## Done
* Set up the project (#1)
* Drop supporting Scala 2.12 (#20)
* Add `api` sub-project and add `chat/completions` (#26)
* Support Scala 3 (#29)
  
  Support Scala 3.2.2. There might be an issue with newtype and refined in Scala 3 as
  * newtype doesn't support Scala 3
  * Some refined features are broken in Scala 3 (e.g. macro for compile-time type check)
* Add `completions.Text` (#34)
  * https://platform.openai.com/docs/api-reference/completions#:~:text=prompt%20and%20parameters.-,Request%20body,-model
* Add `completions.Response` (#37)
  * https://platform.openai.com/docs/api-reference/completions/create#:~:text=%22%5Cn%22%0A%7D-,Response
* Add `CompletionsApi` (#40)
  ```scala
  import openai4s.types.completions
  
  val completionsApi = CompletionsApi[F](completionsUri, apiKey, httpClient)
  val text = completions.Text(
    model = completions.Model.text_Davinci_003,
    prompt = completions.Text.Prompt(NonEmptyString("What is tagless final?")).some,
    maxTokens = completions.Text.MaxTokens(PosInt(2048)).some,
    temperature = completions.Text.Temperature.unsafeFrom(0.2f).some,
    topP = none,
    n = none,
    stream = none,
    logprobs = none,
    stop = none,
  )
  completionsApi.completions(text)
  ```
