### PR TITLE
Fix #54 - Compile-time validation of Uri.apply doesn't work in Scala 3

### DIFF
--- a/modules/openai4s-core/shared/src/main/scala-3/refined4s/InlinedRefined.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/refined4s/InlinedRefined.scala
@@ -1,0 +1,18 @@
+package refined4s
+
+import scala.compiletime.*
+
+/** @author Kevin Lee
+  * @since 2023-08-12
+  */
+trait InlinedRefined[A] extends RefinedBase[A] {
+
+  inline def inlinedInvalidReason(inline a: A): String
+
+  inline def inlinedPredicate(inline a: A): Boolean
+
+  inline def apply(inline a: A): Type =
+    inline if inlinedPredicate(a) then a.asInstanceOf[Type] // scalafix:ok DisableSyntax.asInstanceOf
+    else error("Invalid value: [" + codeOf(a) + "]. " + inlinedInvalidReason(a))
+
+}

--- a/modules/openai4s-core/shared/src/main/scala-3/refined4s/Refined.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/refined4s/Refined.scala
@@ -1,34 +1,16 @@
 package refined4s
 
+import scala.compiletime.*
+
 /** Copied from https://gist.github.com/kevin-lee/158d3d5c3e036560f8962087a34c95c5 and modified.
   * @author Kevin Lee
   * @since 2022-03-23
   */
-trait Refined[A] {
-  import compiletime.*
 
-  opaque type Type = A
-
-  given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived
+trait Refined[A] extends RefinedBase[A] {
 
   inline def apply(a: A): Type =
-    inline if predicate(a) then a else error("Invalid value: [" + codeOf(a) + "]. " + invalidReason(a))
+    inline if predicate(a) then a.asInstanceOf[Type] // scalafix:ok DisableSyntax.asInstanceOf
+    else error("Invalid value: [" + codeOf(a) + "]. " + invalidReason(a))
 
-  def unapply(typ: Type): Option[A] = Some(typ)
-
-  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def from(a: A): Either[String, Type] =
-    if predicate(a) then Right(a) else Left("Invalid value: [" + a.toString + "]. " + invalidReason(a))
-
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  def unsafeFrom(a: A): Type =
-    from(a).fold(err => throw new IllegalArgumentException(err), identity) // scalafix:ok DisableSyntax.throw
-
-  def invalidReason(a: A): String
-
-  def predicate(a: A): Boolean
-
-  extension (typ: Type) {
-    inline def value: A = typ
-  }
 }

--- a/modules/openai4s-core/shared/src/main/scala-3/refined4s/RefinedBase.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/refined4s/RefinedBase.scala
@@ -1,0 +1,30 @@
+package refined4s
+
+/** Copied from https://gist.github.com/kevin-lee/158d3d5c3e036560f8962087a34c95c5 and modified.
+  * @author Kevin Lee
+  * @since 2022-03-23
+  */
+trait RefinedBase[A] {
+
+  opaque type Type = A
+
+  given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived
+
+  def unapply(typ: Type): Option[A] = Some(typ)
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def from(a: A): Either[String, Type] =
+    if predicate(a) then Right(a) else Left("Invalid value: [" + a.toString + "]. " + invalidReason(a))
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFrom(a: A): Type =
+    from(a).fold(err => throw new IllegalArgumentException(err), identity) // scalafix:ok DisableSyntax.throw
+
+  def invalidReason(a: A): String
+
+  def predicate(a: A): Boolean
+
+  extension (typ: Type) {
+    inline def value: A = typ
+  }
+}

--- a/modules/openai4s-core/shared/src/main/scala-3/refined4s/strings.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/refined4s/strings.scala
@@ -1,7 +1,10 @@
 package refined4s
 
 import scala.annotation.targetName
+import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
+import scala.compiletime.*
+import scala.quoted.*
 
 /** @author Kevin Lee
   * @since 2023-04-23
@@ -24,8 +27,12 @@ object strings {
   }
 
   type Uri = Uri.Type
-  object Uri extends Refined[String] {
-    override inline def invalidReason(a: String): String =
+  object Uri extends InlinedRefined[String] {
+
+    override def invalidReason(a: String): String =
+      "It has to be a URI but got [" + a + "]"
+
+    override inline def inlinedInvalidReason(inline a: String): String =
       "It has to be a URI but got [" + a + "]"
 
     override def predicate(a: String): Boolean =
@@ -36,6 +43,29 @@ object strings {
         case NonFatal(_) =>
           false
       }
+
+    override inline def inlinedPredicate(inline uri: String): Boolean = ${ validateUri('uri) }
+
+    private def validateUri(uriExpr: Expr[String])(using Quotes): Expr[Boolean] = {
+      import quotes.reflect.*
+      uriExpr.asTerm match {
+        case Inlined(_, _, Literal(StringConstant(uriStr))) =>
+          try {
+            new java.net.URI(uriStr)
+            Expr(true)
+          } catch {
+            case _: Throwable => Expr(false)
+          }
+        case _ =>
+          report.error(
+            """Uri must be a string literal.
+              |If it's unknown in compile-time, use `Uri.from` or `Uri.unsafeFrom` instead.
+              |(unsafeFrom is not recommended)""".stripMargin,
+            uriExpr,
+          )
+          Expr(false)
+      }
+    }
 
   }
 }


### PR DESCRIPTION
Fix #54 - Compile-time validation of Uri.apply doesn't work in Scala 3