### PR TITLE
openai4s v0.1.0-alpha2

### DIFF
--- a/changelogs/0.1.0-alpha2.md
+++ b/changelogs/0.1.0-alpha2.md
@@ -1,0 +1,72 @@
+## [0.1.0-alpha2](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-06-26..2023-08-30) - 2023-08-30
+
+## Changed
+* Simplify some text types (#53)
+* Add the default Open AI API `Uri` (`ApiUri`) (#57)
+  ```scala
+  ApiUri.default: ApiUri // ApiUri with https://api.openai.com
+  ```
+* Simplify creation of `openai4s.types.chat.Chat.Message` (#60)
+
+  Instead of
+  ```scala
+  import openai4s.types.chat
+  import openai4s.types
+  
+  chat.Chat.Message(
+    types.Message(
+      Message.Role("user"),
+      Message.Content("blah blah"),
+    )
+  )
+  ```
+  it can be
+  ```scala
+  import openai4s.types.chat
+  
+  chat.Chat.Message(
+    Message.Role("user"),
+    Message.Content("blah blah"),
+  )
+  ```
+* Add `ApiCore` to share `HttpClient` and `ApiKey` (#62)
+* Add smart constructors for newtypes in Scala 3 to simplify newtype creation (#64)
+
+  With the current `Newtype` in Scala 3 (openai4s's newtype support for Scala 3), the code looks like this
+  ```scala 3
+  type MaxTokens = MaxTokens.Type
+  object MaxTokens extends Newtype[PosInt]
+  
+  MaxTokens(PosInt(123)) // valid
+  MaxTokens(PosInt(-123)) // compile-time error
+  ```
+  In Scala 2, it could be simplified by importing `eu.timepit.refined.auto.*`.
+  
+  e.g.) In Scala 2,
+  ```scala
+  import eu.timepit.refined.auto.*
+  
+  MaxTokens(123) // valid
+  MaxTokens(-123) // compile-time error
+  ```
+  ***
+  Now in Scala, it could be something similar.
+  ```scala 3
+  type MaxTokens = MaxTokens.Type
+  object MaxTokens extends Newtype[PosInt] {
+    inline def apply(inline token: Int): MaxTokens
+  }
+  ```
+  then it could be simplified like
+  ```scala
+  MaxTokens(PosInt(123)) // valid
+  MaxTokens(PosInt(-123)) // compile-time error
+  
+  MaxTokens(123) // valid
+  MaxTokens(-123) // compile-time error
+  ```
+
+
+## Fixed
+* Compile-time validation of `Uri.apply` doesn't work in Scala 3 (#54)
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha2"


### PR DESCRIPTION
# openai4s v0.1.0-alpha2
## [0.1.0-alpha2](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-06-26..2023-08-30) - 2023-08-30

## Changed
* Simplify some text types (#53)
* Add the default Open AI API `Uri` (`ApiUri`) (#57)
  ```scala
  ApiUri.default: ApiUri // ApiUri with https://api.openai.com
  ```
* Simplify creation of `openai4s.types.chat.Chat.Message` (#60)

  Instead of
  ```scala
  import openai4s.types.chat
  import openai4s.types
  
  chat.Chat.Message(
    types.Message(
      Message.Role("user"),
      Message.Content("blah blah"),
    )
  )
  ```
  it can be
  ```scala
  import openai4s.types.chat
  
  chat.Chat.Message(
    Message.Role("user"),
    Message.Content("blah blah"),
  )
  ```
* Add `ApiCore` to share `HttpClient` and `ApiKey` (#62)
* Add smart constructors for newtypes in Scala 3 to simplify newtype creation (#64)

  With the current `Newtype` in Scala 3 (openai4s's newtype support for Scala 3), the code looks like this
  ```scala 3
  type MaxTokens = MaxTokens.Type
  object MaxTokens extends Newtype[PosInt]
  
  MaxTokens(PosInt(123)) // valid
  MaxTokens(PosInt(-123)) // compile-time error
  ```
  In Scala 2, it could be simplified by importing `eu.timepit.refined.auto.*`.
  
  e.g.) In Scala 2,
  ```scala
  import eu.timepit.refined.auto.*
  
  MaxTokens(123) // valid
  MaxTokens(-123) // compile-time error
  ```
  ***
  Now in Scala, it could be something similar.
  ```scala 3
  type MaxTokens = MaxTokens.Type
  object MaxTokens extends Newtype[PosInt] {
    inline def apply(inline token: Int): MaxTokens
  }
  ```
  then it could be simplified like
  ```scala
  MaxTokens(PosInt(123)) // valid
  MaxTokens(PosInt(-123)) // compile-time error
  
  MaxTokens(123) // valid
  MaxTokens(-123) // compile-time error
  ```


## Fixed
* Compile-time validation of `Uri.apply` doesn't work in Scala 3 (#54)

