### PR TITLE
openai4s v0.1.0-alpha4

### DIFF
--- a/changelogs/0.1.0-alpha4.md
+++ b/changelogs/0.1.0-alpha4.md
@@ -1,0 +1,13 @@
+## [0.1.0-alpha4](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-03..2023-09-03) - 2023-09-03
+
+## Added
+* Add `Show[HttpError[F]]` type-class instance for Scala 3 (#79)
+* Update available ChatGPT models - GPT 4 models with 32k tokens are not available yet (#80)
+
+  More about the models can be found at the following links.
+  * [Model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility)
+  * [GPT-4](https://platform.openai.com/docs/models/gpt-4)
+  * [GPT-3.5](https://platform.openai.com/docs/models/gpt-3-5)
+  
+  > NOTE: GPT 4 Models with 32k tokens (context length) are not available yet.
+  > Reference: [https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4](https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha4"


### PR DESCRIPTION
# openai4s v0.1.0-alpha4
## [0.1.0-alpha4](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-03..2023-09-03) - 2023-09-03

## Added
* Add `Show[HttpError[F]]` type-class instance for Scala 3 (#79)
* Update available ChatGPT models - GPT 4 models with 32k tokens are not available yet (#80)

  More about the models can be found at the following links.
  * [Model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility)
  * [GPT-4](https://platform.openai.com/docs/models/gpt-4)
  * [GPT-3.5](https://platform.openai.com/docs/models/gpt-3-5)
  
  > NOTE: GPT 4 Models with 32k tokens (context length) are not available yet.
  > Reference: [https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4](https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4)
