### PR TITLE
openai4s v0.1.0-alpha5

### DIFF
--- a/changelogs/0.1.0-alpha5.md
+++ b/changelogs/0.1.0-alpha5.md
@@ -1,0 +1,13 @@
+## [0.1.0-alpha5](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-04..2023-09-09) - 2023-09-10
+
+## Changed
+* Update `UnexpectedStatus` to handle more response body cases (#88)
+
+  `UnexpectedStatus` had `request: Request[F], status: Status, body: Option[String]`.
+  
+  From 0.1.0-alpha5, it is changed to have one of
+  * `Json`
+  * `String`
+  * any exception that might be thrown while getting the above type values.
+
+  for `body` instead of having optional `String` (`Option[String]`).

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha5"


### PR DESCRIPTION
# openai4s v0.1.0-alpha5
## [0.1.0-alpha5](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-04..2023-09-09) - 2023-09-10

## Changed
* Update `UnexpectedStatus` to handle more response body cases (#88)

  `UnexpectedStatus` had `request: Request[F], status: Status, body: Option[String]`.
  
  From 0.1.0-alpha5, it is changed to have one of
  * `Json`
  * `String`
  * any exception that might be thrown while getting the above type values.

  for `body` instead of having optional `String` (`Option[String]`).
