### PR TITLE
openai4s v0.1.0-alpha6

### DIFF
--- a/changelogs/0.1.0-alpha6.md
+++ b/changelogs/0.1.0-alpha6.md
@@ -1,0 +1,53 @@
+## [0.1.0-alpha6](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-10..2023-11-11) - 2023-11-11
+
+## New Features
+
+* Add support for GPT-4 Turbo models (#101)
+  
+  OpenAI announced a public release of GPT-4 and GPT-4 Turbo a few days ago.
+    * `gpt-4-1106-preview`
+    * `gpt-4-vision-preview`
+
+  The turbo models have a context length of 128,000 tokens, so it's worth having them soon.
+
+## Improvement
+
+* Simplify creation of `openai4s.types.chat.Response.Choice.Message` (#95)
+
+  Instead of
+  ```scala
+  import openai4s.types
+  import openai4s.types.chat.*
+  
+  Response.Choice.Message(
+    types.Message(
+      types.Message.Role("assistant"),
+      types.Message.Content("content value")
+    )
+  )
+  ```
+  it could be
+  ```scala
+  import openai4s.types
+  import openai4s.types.chat.*
+  
+  Response.Choice.Message(
+    types.Message.Role("assistant"),
+    types.Message.Content("content value")
+  )
+  ```
+
+* Add experimental syntax for `NonEmptyString` in Scala 3 (#97)
+
+## Internal Housekeeping
+
+* Upgrade Scala, sbt and sbt plugins (#103)
+    * Scala 2 to `2.13.12`
+    * Scala 3 to `3.3.1`
+    * sbt to `1.9.7`
+    * `sbt-wartremover` to `3.1.5`
+    * `sbt-tpolecat` to `0.5.0`
+    * `sbt-scalafix` to `0.11.1`
+    * `sbt-scalafmt` to `2.5.2`
+    * `sbt-scoverage` to `2.0.9`
+    * `sbt-mdoc` to `2.5.1`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-alpha5"
+ThisBuild / version := "0.1.0-alpha6"


### PR DESCRIPTION
# openai4s v0.1.0-alpha6
## [0.1.0-alpha6](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-09-10..2023-11-11) - 2023-11-11

## New Features

* Add support for GPT-4 Turbo models (#101)
  
  OpenAI announced a public release of GPT-4 and GPT-4 Turbo a few days ago.
    * `gpt-4-1106-preview`
    * `gpt-4-vision-preview`

  The turbo models have a context length of 128,000 tokens, so it's worth having them soon.

## Improvement

* Simplify creation of `openai4s.types.chat.Response.Choice.Message` (#95)

  Instead of
  ```scala
  import openai4s.types
  import openai4s.types.chat.*
  
  Response.Choice.Message(
    types.Message(
      types.Message.Role("assistant"),
      types.Message.Content("content value")
    )
  )
  ```
  it could be
  ```scala
  import openai4s.types
  import openai4s.types.chat.*
  
  Response.Choice.Message(
    types.Message.Role("assistant"),
    types.Message.Content("content value")
  )
  ```

* Add experimental syntax for `NonEmptyString` in Scala 3 (#97)

## Internal Housekeeping

* Upgrade Scala, sbt and sbt plugins (#103)
    * Scala 2 to `2.13.12`
    * Scala 3 to `3.3.1`
    * sbt to `1.9.7`
    * `sbt-wartremover` to `3.1.5`
    * `sbt-tpolecat` to `0.5.0`
    * `sbt-scalafix` to `0.11.1`
    * `sbt-scalafmt` to `2.5.2`
    * `sbt-scoverage` to `2.0.9`
    * `sbt-mdoc` to `2.5.1`
