### PR TITLE
openai4s v0.1.0-alpha7

### DIFF
--- a/changelogs/0.1.0-alpha7.md
+++ b/changelogs/0.1.0-alpha7.md
@@ -1,0 +1,9 @@
+## [0.1.0-alpha7](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-11-12..2023-11-26) - 2023-11-26
+
+## Changes
+* Re-organize data model (#106)
+
+  The following data types are now shared
+  * `Message` used for `Chat` and `Response.Choice`
+  * `Temperature` and `MaxTokens` for `Chat` and `Text`
+  * `Index` and `FinishReason` for `Response` for `Chat` and `Text`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-alpha6"
+ThisBuild / version := "0.1.0-alpha7"


### PR DESCRIPTION
# openai4s v0.1.0-alpha7
## [0.1.0-alpha7](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-11-12..2023-11-26) - 2023-11-26

## Changes
* Re-organize data model (#106)

  The following data types are now shared
  * `Message` used for `Chat` and `Response.Choice`
  * `Temperature` and `MaxTokens` for `Chat` and `Text`
  * `Index` and `FinishReason` for `Response` for `Chat` and `Text`
