### PR TITLE
Close #118 - Replace more types for Scala 3 with refined4s's

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val props =
 
     val NewtypeVersion = "0.4.4"
 
-    val Refined4sVersion = "0.8.0"
+    val Refined4sVersion = "0.10.0"
 
     val TypeLevelCaseInsensitiveVersion = "1.4.0"
 
@@ -236,11 +236,12 @@ lazy val libs = new {
 
   lazy val refined4s =
     List(
-      "io.kevinlee" %% "refined4s-core"       % props.Refined4sVersion,
-      "io.kevinlee" %% "refined4s-cats"       % props.Refined4sVersion,
-      "io.kevinlee" %% "refined4s-circe"      % props.Refined4sVersion,
-      "io.kevinlee" %% "refined4s-pureconfig" % props.Refined4sVersion,
-      "io.kevinlee" %% "refined4s-doobie-ce3" % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-core"          % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-cats"          % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-circe"         % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-pureconfig"    % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-doobie-ce3"    % props.Refined4sVersion,
+      "io.kevinlee" %% "refined4s-extras-render" % props.Refined4sVersion,
     )
 
   def refined(scalaVersion: String): List[ModuleID] =

--- a/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/ApiUri.scala
+++ b/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/ApiUri.scala
@@ -1,13 +1,18 @@
 package openai4s.config
 
 import cats.{Eq, Show}
-import cats.syntax.all.*
 import extras.render.Render
 import extras.render.syntax.*
 import pureconfig.*
 import pureconfig.generic.derivation.default.*
-import pureconfig.error.CannotConvert
+import refined4s.*
 import refined4s.types.all.*
+import refined4s.modules.cats.derivation.*
+import refined4s.modules.cats.derivation.types.all.given
+import refined4s.modules.pureconfig.derivation.PureconfigNewtypeConfigReader
+import refined4s.modules.pureconfig.derivation.types.all.given
+import refined4s.modules.extras.derivation.*
+import refined4s.modules.extras.derivation.types.all.given
 
 /** @author Kevin Lee
   * @since 2023-04-07
@@ -33,26 +38,7 @@ object ApiUri {
       NonEmptyString.unsafeFrom(render"${apiUri.baseUri}/v1/completions")
   }
 
-  type BaseUri = BaseUri.BaseUri
-  object BaseUri {
-    opaque type BaseUri = Uri
-    def apply(baseUri: Uri): BaseUri = baseUri
-
-    given baseUriCanEqual: CanEqual[BaseUri, BaseUri] = CanEqual.derived
-
-    extension (baseUri: BaseUri) {
-      def value: Uri = baseUri
-    }
-
-    given baseUriEq: Eq[BaseUri] = Eq.fromUniversalEquals
-
-    given baseUriRender: Render[BaseUri] = Render.stringRender.contramap(_.value.value)
-    given baseUriShow: Show[BaseUri]     = Show.catsShowForString.contramap(_.value.value)
-
-    given baseUriConfigReader: ConfigReader[BaseUri] = ConfigReader
-      .stringConfigReader
-      .emap(s => Uri.from(s).leftMap(err => CannotConvert(s, "refined4s.types.all.Uri", err)))
-
-  }
+  type BaseUri = BaseUri.Type
+  object BaseUri extends Newtype[Uri], CatsEqShow[Uri], PureconfigNewtypeConfigReader[Uri], ExtrasRender[Uri]
 
 }

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Message.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Message.scala
@@ -10,6 +10,7 @@ import io.circe.{Decoder, Encoder}
 import refined4s.*
 import refined4s.modules.cats.derivation.*
 import refined4s.modules.circe.derivation.*
+import refined4s.modules.extras.derivation.*
 
 /** @author Kevin Lee
   * @since 2023-03-24
@@ -19,17 +20,9 @@ object Message {
   given messageConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
 
   type Role = Role.Type
-  object Role extends Newtype[String] with CatsEqShow[String] with CirceNewtypeCodec[String] {
-
-    given roleRender: Render[Role] = Render.render(_.value)
-
-  }
+  object Role extends Newtype[String], CatsEqShow[String], CirceNewtypeCodec[String], ExtrasRender[String]
 
   type Content = Content.Type
-  object Content extends Newtype[String] with CatsEqShow[String] with CirceNewtypeCodec[String] {
-
-    given contentRender: Render[Content] = Render.render(_.value)
-
-  }
+  object Content extends Newtype[String], CatsEqShow[String], CirceNewtypeCodec[String], ExtrasRender[String]
 
 }

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Response.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Response.scala
@@ -12,6 +12,8 @@ import refined4s.modules.cats.derivation.*
 import refined4s.modules.cats.derivation.types.all.given
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
+import refined4s.modules.extras.derivation.*
+import refined4s.modules.extras.derivation.types.all.given
 
 import openai4s.types.common.*
 
@@ -35,20 +37,18 @@ object Response {
   given responseConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
 
   type Id = Id.Type
-  object Id extends Newtype[NonEmptyString], CatsEqShow[NonEmptyString] {
-
-    given idRender: Render[Id] = Render[String].contramap(_.toValue)
-
-    given idEncoder: Encoder[Id] = Encoder[String].contramap(_.toValue)
-    given idDecoder: Decoder[Id] = Decoder[String].emap(NonEmptyString.from).map(Id(_))
-  }
+  object Id
+      extends Newtype[NonEmptyString],
+        CatsEqShow[NonEmptyString],
+        CirceNewtypeCodec[NonEmptyString],
+        ExtrasRender[NonEmptyString]
 
   type Object = Object.Type
-  object Object extends Newtype[NonEmptyString], CatsEqShow[NonEmptyString], CirceNewtypeCodec[NonEmptyString] {
-
-    given objectRender: Render[Object] = Render[String].contramap(_.toValue)
-
-  }
+  object Object
+      extends Newtype[NonEmptyString],
+        CatsEqShow[NonEmptyString],
+        CirceNewtypeCodec[NonEmptyString],
+        ExtrasRender[NonEmptyString]
 
   type Created = Created.Type
   object Created extends Newtype[Instant] {
@@ -72,25 +72,13 @@ object Response {
   object Usage {
 
     type PromptTokens = PromptTokens.Type
-    object PromptTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int] {
-
-      given promptTokensRender: Render[PromptTokens] = deriving
-
-    }
+    object PromptTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
     type CompletionTokens = CompletionTokens.Type
-    object CompletionTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int] {
-
-      given completionTokensRender: Render[CompletionTokens] = deriving
-
-    }
+    object CompletionTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
     type TotalTokens = TotalTokens.Type
-    object TotalTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int] {
-
-      given totalTokensRender: Render[TotalTokens] = deriving
-
-    }
+    object TotalTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
   }
 

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/common.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/common.scala
@@ -9,6 +9,8 @@ import refined4s.modules.cats.derivation.*
 import refined4s.modules.cats.derivation.types.all.given
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
+import refined4s.modules.extras.derivation.*
+import refined4s.modules.extras.derivation.types.all.given
 import refined4s.types.all.*
 
 import scala.annotation.targetName
@@ -37,26 +39,30 @@ object common {
     @targetName("fromInt")
     inline def apply(inline token: Int): Type = wrap(PosInt(token))
 
+    def from(token: Int): Either[String, MaxTokens] = PosInt.from(token).map(wrap(_))
+
+    def unsafeFrom(token: Int): MaxTokens = wrap(PosInt.unsafeFrom(token))
+
   }
 
   type Index = Index.Type
-  object Index extends Newtype[NonNegInt] with CatsEqShow[NonNegInt] with CirceNewtypeCodec[NonNegInt] {
+  object Index
+      extends Newtype[NonNegInt],
+        CatsEqShow[NonNegInt],
+        CirceNewtypeCodec[NonNegInt],
+        ExtrasRender[NonNegInt] {
 
     @targetName("fromInt")
     inline def apply(inline index: Int): Index = wrap(NonNegInt(index))
 
-    def unsafeFrom(index: Int): Index = wrap(NonNegInt.unsafeFrom(index))
+    def from(index: Int): Either[String, Index] = NonNegInt.from(index).map(wrap(_))
 
-    given indexRender: Render[Index] = Render.intRender.contramap(_.toValue)
+    def unsafeFrom(index: Int): Index = wrap(NonNegInt.unsafeFrom(index))
 
   }
 
   type FinishReason = FinishReason.Type
 
-  object FinishReason extends Newtype[String] with CatsEqShow[String] with CirceNewtypeCodec[String] {
-
-    given finishReasonRender: Render[FinishReason] = deriving
-
-  }
+  object FinishReason extends Newtype[String], CatsEqShow[String], CirceNewtypeCodec[String], ExtrasRender[String]
 
 }

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Response.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Response.scala
@@ -1,6 +1,5 @@
 package openai4s.types.completions
 
-import cats.syntax.all.*
 import cats.{Eq, Show}
 import extras.render.Render
 import io.circe.derivation.{Configuration, ConfiguredCodec, ConfiguredDecoder, ConfiguredEncoder}
@@ -8,7 +7,13 @@ import io.circe.{Codec, Decoder, Encoder}
 import refined4s.*
 import openai4s.types
 import openai4s.types.common.*
-import refined4s.types.all.NonEmptyString
+import refined4s.types.all.*
+import refined4s.modules.cats.derivation.*
+import refined4s.modules.cats.derivation.types.all.given
+import refined4s.modules.circe.derivation.*
+import refined4s.modules.circe.derivation.types.all.given
+import refined4s.modules.extras.derivation.*
+import refined4s.modules.extras.derivation.types.all.given
 
 import java.time.Instant
 
@@ -36,33 +41,18 @@ object Response {
   given decoder: Decoder[Response] = ConfiguredDecoder.derived
 
   type Id = Id.Type
-  object Id extends Newtype[NonEmptyString] {
-    extension (id: Id) {
-      def toValue: String = id.value.value
-    }
-
-    given idEq: Eq[Id] = Eq.fromUniversalEquals
-
-    given idRender: Render[Id] = Render[String].contramap(_.toValue)
-    given idShow: Show[Id]     = Show[String].contramap(_.toValue)
-
-    given idEncoder: Encoder[Id] = Encoder[String].contramap(_.toValue)
-    given idDecoder: Decoder[Id] = Decoder[String].emap(NonEmptyString.from).map(Id(_))
-  }
+  object Id
+      extends Newtype[NonEmptyString],
+        CatsEqShow[NonEmptyString],
+        CirceNewtypeCodec[NonEmptyString],
+        ExtrasRender[NonEmptyString]
 
   type Object = Object.Type
-  object Object extends Newtype[NonEmptyString] {
-    extension (obj: Object) {
-      def toValue: String = obj.value.value
-    }
-    given objectEq: Eq[Object] = Eq.fromUniversalEquals
-
-    given objectRender: Render[Object] = Render[String].contramap(_.toValue)
-    given objectShow: Show[Object]     = Show[String].contramap(_.toValue)
-
-    given objectEncoder: Encoder[Object] = Encoder[String].contramap(_.toValue)
-    given objectDecoder: Decoder[Object] = Decoder[String].emap(NonEmptyString.from).map(Object(_))
-  }
+  object Object
+      extends Newtype[NonEmptyString],
+        CatsEqShow[NonEmptyString],
+        CirceNewtypeCodec[NonEmptyString],
+        ExtrasRender[NonEmptyString]
 
   type Created = Created.Type
   object Created extends Newtype[Instant] {
@@ -90,25 +80,14 @@ object Response {
     given choiceCodec: Codec[Choice] = ConfiguredCodec.derived
 
     type Text = Text.Type
-    object Text extends Newtype[NonEmptyString] {
-      given textEq: Eq[Text] = Eq.fromUniversalEquals
-
-      given textShow: Show[Text]     = Show.show(_.value.value)
-      given textRender: Render[Text] = Render.render(_.value.value)
-
-      given textEncoder: Encoder[Text] = Encoder[String].contramap(_.value.value)
-      given textDecoder: Decoder[Text] = Decoder[String].emap(NonEmptyString.from).map(Text(_))
-    }
+    object Text
+        extends Newtype[NonEmptyString],
+          CatsEqShow[NonEmptyString],
+          CirceNewtypeCodec[NonEmptyString],
+          ExtrasRender[NonEmptyString]
 
     type Logprobs = Logprobs.Type
-    object Logprobs extends Newtype[Int] {
-      given logprobsEq: Eq[Logprobs] = Eq.fromUniversalEquals
-
-      given logprobsShow: Show[Logprobs] = Show.catsShowForInt.contramap(_.value)
-
-      given logprobsEncoder: Encoder[Logprobs] = Encoder.encodeInt.contramap(_.value)
-      given logprobsDecoder: Decoder[Logprobs] = Decoder.decodeInt.map(Logprobs(_))
-    }
+    object Logprobs extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
   }
 
@@ -125,39 +104,13 @@ object Response {
     given usageCodec: Codec[Usage] = ConfiguredCodec.derived
 
     type PromptTokens = PromptTokens.Type
-    object PromptTokens extends Newtype[Int] {
-
-      given promptTokensEq: Eq[PromptTokens] = Eq.fromUniversalEquals
-
-      given promptTokensShow: Show[PromptTokens]     = Show.catsShowForInt.contramap(_.value)
-      given promptTokensRender: Render[PromptTokens] = Render.intRender.contramap(_.value)
-
-      given promptTokensEncoder: Encoder[PromptTokens] = Encoder.encodeInt.contramap(_.value)
-      given promptTokensDecoder: Decoder[PromptTokens] = Decoder.decodeInt.map(PromptTokens(_))
-    }
+    object PromptTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
     type CompletionTokens = CompletionTokens.Type
-    object CompletionTokens extends Newtype[Int] {
-
-      given completionTokensEq: Eq[CompletionTokens] = Eq.fromUniversalEquals
-
-      given completionTokensShow: Show[CompletionTokens]     = Show.catsShowForInt.contramap(_.value)
-      given completionTokensRender: Render[CompletionTokens] = Render.intRender.contramap(_.value)
-
-      given completionTokensEncoder: Encoder[CompletionTokens] = Encoder.encodeInt.contramap(_.value)
-      given completionTokensDecoder: Decoder[CompletionTokens] = Decoder.decodeInt.map(CompletionTokens(_))
-    }
+    object CompletionTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
     type TotalTokens = TotalTokens.Type
-    object TotalTokens extends Newtype[Int] {
-      given totalTokensEq: Eq[TotalTokens] = Eq.fromUniversalEquals
-
-      given totalTokensShow: Show[TotalTokens]     = Show.catsShowForInt.contramap(_.value)
-      given totalTokensRender: Render[TotalTokens] = Render.intRender.contramap(_.value)
-
-      given totalTokensEncoder: Encoder[TotalTokens] = Encoder.encodeInt.contramap(_.value)
-      given totalTokensDecoder: Decoder[TotalTokens] = Decoder.decodeInt.map(TotalTokens(_))
-    }
+    object TotalTokens extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int], ExtrasRender[Int]
 
   }
 

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Text.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Text.scala
@@ -10,6 +10,10 @@ import refined4s.*
 import refined4s.types.all.*
 import refined4s.modules.cats.derivation.*
 import refined4s.modules.cats.derivation.types.all.given
+import refined4s.modules.circe.derivation.*
+import refined4s.modules.circe.derivation.types.all.given
+import refined4s.modules.extras.derivation.*
+import refined4s.modules.extras.derivation.types.all.given
 
 import scala.annotation.targetName
 
@@ -42,29 +46,18 @@ object Text {
   given textDecoder: Decoder[Text] = ConfiguredDecoder.derived
 
   type Prompt = Prompt.Type
-  object Prompt extends Newtype[String] with CatsEqShow[String] {
-    given promptRender: Render[Prompt] = Render.render(_.value)
-
-    given promptEncoder: Encoder[Prompt] = Encoder[String].contramap(_.value)
-    given promptDecoder: Decoder[Prompt] = Decoder[String].map(Prompt(_))
-  }
+  object Prompt extends Newtype[String], CatsEqShow[String], ExtrasRender[String], CirceNewtypeCodec[String]
 
   type TopP = TopP.Type
-  object TopP extends Newtype[NonNegFloat] with CatsEqShow[NonNegFloat] {
+  object TopP extends Newtype[NonNegFloat], CatsEqShow[NonNegFloat], CirceNewtypeCodec[NonNegFloat] {
 
     @targetName("fromFloat")
     inline def apply(inline a: Float): Type = wrap(NonNegFloat(a))
 
-    given topPEncoder: Encoder[TopP] = Encoder[Float].contramap(_.value.value)
-    given topPDecoder: Decoder[TopP] = Decoder[Float].emap(NonNegFloat.from).map(TopP(_))
   }
 
   type N = N.Type
-  object N extends Newtype[Int] with CatsEqShow[Int] {
-
-    given nEncoder: Encoder[N] = Encoder[Int].contramap(_.value)
-    given nDecoder: Decoder[N] = Decoder[Int].map(N(_))
-  }
+  object N extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int]
 
   enum Stream {
     case IsStream
@@ -92,19 +85,17 @@ object Text {
   }
 
   type Logprobs = Logprobs.Type
-  object Logprobs extends Newtype[Int] with CatsEqShow[Int] {
-
-    given logprobsEncoder: Encoder[Logprobs] = Encoder[Int].contramap(_.value)
-    given logprobsDecoder: Decoder[Logprobs] = Decoder[Int].map(Logprobs(_))
-  }
+  object Logprobs extends Newtype[Int], CatsEqShow[Int], CirceNewtypeCodec[Int]
 
   type Stop = Stop.Type
-  object Stop extends Newtype[NonEmptyString] with CatsEqShow[NonEmptyString] {
+  object Stop
+      extends Newtype[NonEmptyString],
+        CatsEqShow[NonEmptyString],
+        ExtrasRender[NonEmptyString],
+        CirceNewtypeCodec[NonEmptyString] {
 
     @targetName("fromString")
     inline def apply(inline a: String): Type = wrap(NonEmptyString(a))
 
-    given stopEncoder: Encoder[Stop] = Encoder[String].contramap(_.value.value)
-    given stopDecoder: Decoder[Stop] = Decoder[String].emap(NonEmptyString.from).map(Stop(_))
   }
 }


### PR DESCRIPTION
Close #118 - Replace more types for Scala 3 with refined4s's
- Bump refined4s to 0.10.0
- Add refined4s-extras-render as a dependency library
- Replace more custom types with refined4s's
- Use refined4s-extras-render and other refined4s type-classes to have simpler newtype definitions