### PR TITLE
openai4s v0.1.0-alpha8

### DIFF
--- a/changelogs/0.1.0-alpha8.md
+++ b/changelogs/0.1.0-alpha8.md
@@ -1,0 +1,11 @@
+## [0.1.0-alpha8](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-11-27..2024-01-15) - 2024-01-15
+
+## Changes
+* Replace custom newtypes and refinement types with `refined4s` (#112)
+* Replace more types for Scala 3 with `refined4s`'s (#118)
+
+## Internal Housekeeping
+* Upgrade `refined4s` to ~~`0.8.0`~~ `0.11.0` (#116)
+* Use more derived type-classes and `hedgehog-extra-refined4s` (#120)
+  * Use Scala 3 `derives` syntax and also use more type-class instances from Kittens.
+  * Use `hedgehog-extra-refined4s` and its pre-defined `Gen`s for refined4s

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha8"


### PR DESCRIPTION
# openai4s v0.1.0-alpha8
## [0.1.0-alpha8](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2023-11-27..2024-01-15) - 2024-01-15

## Changes
* Replace custom newtypes and refinement types with `refined4s` (#112)
* Replace more types for Scala 3 with `refined4s`'s (#118)

## Internal Housekeeping
* Upgrade `refined4s` to ~~`0.8.0`~~ `0.11.0` (#116)
* Use more derived type-classes and `hedgehog-extra-refined4s` (#120)
  * Use Scala 3 `derives` syntax and also use more type-class instances from Kittens.
  * Use `hedgehog-extra-refined4s` and its pre-defined `Gen`s for refined4s
