### PR TITLE
Fix #139 - Missing model handling in `Model.fromString` (Scala 2)

### DIFF
--- a/modules/openai4s-core/shared/src/main/scala-2/openai4s/types/chat/Model.scala
+++ b/modules/openai4s-core/shared/src/main/scala-2/openai4s/types/chat/Model.scala
@@ -97,29 +97,8 @@ object Model {
       Model.gpt_3_5_Turbo_0301,
     )
 
-  def fromString(model: String): Either[String, Model] = model match {
-    case Gpt_4_1106_Preview.value.value => gpt_4_1106_Preview.asRight
-    case Gpt_4_Vision_Preview.value.value => gpt_4_Vision_Preview.asRight
-
-    case Gpt_4.value.value => gpt_4.asRight
-    case Gpt_4_32k.value.value => gpt_4_32k.asRight
-
-    case Gpt_4_0613.value.value => gpt_4_0613.asRight
-    case Gpt_4_32k_0613.value.value => gpt_4_32k_0613.asRight
-
-    case Gpt_4_0314.value.value => gpt_4_0314.asRight
-    case Gpt_4_32k_0314.value.value => gpt_4_32k_0314.asRight
-
-    case Gpt_3_5_Turbo.value.value => gpt_3_5_Turbo.asRight
-    case Gpt_3_5_turbo_16k.value.value => gpt_3_5_turbo_16k.asRight
-
-    case Gpt_3_5_turbo_0613.value.value => gpt_3_5_turbo_0613.asRight
-    case Gpt_3_5_turbo_16k_0613.value.value => gpt_3_5_turbo_16k_0613.asRight
-
-    case Gpt_3_5_Turbo_0301.value.value => gpt_3_5_Turbo_0301.asRight
-
-    case _ => s"Unknown model: $model".asLeft
-  }
+  def fromString(model: String): Either[String, Model] =
+    Model.supportedValues.find(_.value.value === model).toRight(s"Unknown model: $model")
 
   implicit val modelEq: Eq[Model] = Eq[NonEmptyString].contramap(_.value)
 

--- a/modules/openai4s-core/shared/src/test/scala/openai4s/types/chat/Gens.scala
+++ b/modules/openai4s-core/shared/src/test/scala/openai4s/types/chat/Gens.scala
@@ -15,21 +15,7 @@ import java.time.Instant
 object Gens extends TypesCompat {
 
   def genModel: Gen[Model] =
-    Gen.element1(
-      Model.gpt_4_1106_Preview,
-      Model.gpt_4_Vision_Preview,
-      Model.gpt_4,
-      Model.gpt_4_32k,
-      Model.gpt_4_0613,
-      Model.gpt_4_32k_0613,
-      Model.gpt_4_0314,
-      Model.gpt_4_32k_0314,
-      Model.gpt_3_5_Turbo,
-      Model.gpt_3_5_turbo_16k,
-      Model.gpt_3_5_turbo_0613,
-      Model.gpt_3_5_turbo_16k_0613,
-      Model.gpt_3_5_Turbo_0301,
-    )
+    Gen.elementUnsafe(Model.supportedValues)
 
   object chat {
 


### PR DESCRIPTION
Fix #139 - Missing model handling in `Model.fromString` (Scala 2)