### PR TITLE
openai4s v0.1.0-alpha9

### DIFF
--- a/changelogs/0.1.0-alpha9.md
+++ b/changelogs/0.1.0-alpha9.md
@@ -1,0 +1,47 @@
+## [0.1.0-alpha9](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2024-01-16..2024-05-25) - 2024-05-26
+
+## New Features
+
+* Update `GPT-4` and `GPT-4 Turbo` models (#139)
+  
+  Update the current Chat models with the models from [GPT-4 and GPT-4 Turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo).
+  * `gpt-4-0125-preview`
+  * `gpt-4-turbo-preview`
+  * `gpt-4-1106-vision-preview`
+
+* Add `description`, `maxTokens` and `trainingData` to `Model` for `Chat` (#142)
+
+* Update `GPT-3.5` Turbo models (#147)
+
+  GPT-3.5 Turbo ([📄](https://platform.openai.com/docs/models/gpt-3-5-turbo))
+  
+  Add the following models
+  * `gpt-3.5-turbo-0125`
+  * `gpt-3.5-turbo-1106`
+  * `gpt-3.5-turbo-instruct`
+
+* Add `GPT-4o` models (#154)
+
+  Add the Chat models from [GPT-4o](https://platform.openai.com/docs/models/gpt-4o).
+  * `gpt-4o`
+  * `gpt-4o-2024-05-13`
+
+* Update `GPT-4` and `GPT-4` Turbo models (#156)
+  
+  Update the current Chat models with the models from [GPT-4 Turbo and GPT-4](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4).
+
+
+## Changes
+
+* Remove deprecated models (#141)
+
+
+## Internal Housekeeping
+
+* Use `refined4s-refined-compat` modules (#125)
+
+* Bump `cats-effect` 3 to `3.5.3` (#129)
+
+* Bump `hedgehog-extra` to `0.7.0` (#130)
+
+* Bump `refined4s` to `0.15.0` (#150)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha9"


### PR DESCRIPTION
# openai4s v0.1.0-alpha9
## [0.1.0-alpha9](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2024-01-16..2024-05-25) - 2024-05-26

## New Features

* Update `GPT-4` and `GPT-4 Turbo` models (#139)
  
  Update the current Chat models with the models from [GPT-4 and GPT-4 Turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo).
  * `gpt-4-0125-preview`
  * `gpt-4-turbo-preview`
  * `gpt-4-1106-vision-preview`

* Add `description`, `maxTokens` and `trainingData` to `Model` for `Chat` (#142)

* Update `GPT-3.5` Turbo models (#147)

  GPT-3.5 Turbo ([📄](https://platform.openai.com/docs/models/gpt-3-5-turbo))
  
  Add the following models
  * `gpt-3.5-turbo-0125`
  * `gpt-3.5-turbo-1106`
  * `gpt-3.5-turbo-instruct`

* Add `GPT-4o` models (#154)

  Add the Chat models from [GPT-4o](https://platform.openai.com/docs/models/gpt-4o).
  * `gpt-4o`
  * `gpt-4o-2024-05-13`

* Update `GPT-4` and `GPT-4` Turbo models (#156)
  
  Update the current Chat models with the models from [GPT-4 Turbo and GPT-4](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4).


## Changes

* Remove deprecated models (#141)


## Internal Housekeeping

* Use `refined4s-refined-compat` modules (#125)

* Bump `cats-effect` 3 to `3.5.3` (#129)

* Bump `hedgehog-extra` to `0.7.0` (#130)

* Bump `refined4s` to `0.15.0` (#150)
