### PR TITLE
Remove dependency to refined4s-doobie

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,6 @@ lazy val libs = new {
         "io.kevinlee"    %% "refined4s-cats"                  % props.Refined4sVersion,
         "io.kevinlee"    %% "refined4s-circe"                 % props.Refined4sVersion,
         "io.kevinlee"    %% "refined4s-pureconfig"            % props.Refined4sVersion,
-        "io.kevinlee"    %% "refined4s-doobie-ce3"            % props.Refined4sVersion,
         "io.kevinlee"    %% "refined4s-extras-render"         % props.Refined4sVersion,
         "io.kevinlee"    %% "refined4s-refined-compat-scala3" % props.Refined4sVersion,
       )


### PR DESCRIPTION
Hi, just came across your library, thanks for your work !
I noticed that there's an unused dependency to refined4s-doobie, which is a bit annoying as I'm using doobie 1.0.0-RC5 on a project, making incompatible with the RC2 version used by refined4s-doobie.
Feel free to close my PR if there's a good reason for this dependency to by there