### PR TITLE
openai4s v0.1.0-alpha10

### DIFF
--- a/changelogs/0.1.0-alpha10.md
+++ b/changelogs/0.1.0-alpha10.md
@@ -1,0 +1,5 @@
+## [0.1.0-alpha10](https://github.com/kevin-lee/openai4s/pulls?q=is%3Apr+is%3Aclosed+milestone%3Am1+label%3Ainclude-in-release-note+closed%3A2024-05-26..2024-08-04) - 2024-08-05
+
+## Internal Housekeeping
+
+* Remove unused `refined4s-doobie` from `libraryDependencies` (#164)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha10"


### PR DESCRIPTION
# openai4s v0.1.0-alpha10
## [0.1.0-alpha10](https://github.com/kevin-lee/openai4s/pulls?q=is%3Apr+is%3Aclosed+milestone%3Am1+label%3Ainclude-in-release-note+closed%3A2024-05-26..2024-08-04) - 2024-08-05

## Internal Housekeeping

* Remove unused `refined4s-doobie` from `libraryDependencies` (#164)
