### PR TITLE
openai4s v0.1.0-alpha11

### DIFF
--- a/changelogs/0.1.0-alpha11.md
+++ b/changelogs/0.1.0-alpha11.md
@@ -1,0 +1,7 @@
+## [0.1.0-alpha11](https://github.com/kevin-lee/openai4s/pulls?q=is%3Apr+is%3Aclosed+milestone%3Am1+label%3Ainclude-in-release-note+closed%3A2024-08-05..2024-08-18) - 2024-08-19
+
+## New Features
+
+* Add [`GPT-4o mini`](https://platform.openai.com/docs/models/gpt-4o-mini) models (#167)
+
+  Thanks @keuhdall

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha11"


### PR DESCRIPTION
# openai4s v0.1.0-alpha11
## [0.1.0-alpha11](https://github.com/kevin-lee/openai4s/pulls?q=is%3Apr+is%3Aclosed+milestone%3Am1+label%3Ainclude-in-release-note+closed%3A2024-08-05..2024-08-18) - 2024-08-19

## New Features

* Add [`GPT-4o mini`](https://platform.openai.com/docs/models/gpt-4o-mini) models (#167)

  Thanks @keuhdall
