### PR TITLE
openai4s v0.1.0-alpha12

### DIFF
--- a/changelogs/0.1.0-alpha12.md
+++ b/changelogs/0.1.0-alpha12.md
@@ -1,0 +1,30 @@
+## [0.1.0-alpha12](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2024-08-19..2024-09-19) - 2024-09-20
+
+## New Features
+
+* Add `o1-preview` Chat models (#170)
+  
+  https://platform.openai.com/docs/models/o1
+***
+
+* Add `Model.MaxTokens` type for `chat.Model.maxTokens` (#172)
+***
+
+* Add `o1-mini` Chat models (#173)
+
+  https://platform.openai.com/docs/models/o1
+***
+
+* Add `chatgpt-4o-latest` chat model (#177)
+
+  https://platform.openai.com/docs/models/gpt-4o
+***
+
+## Changes
+
+* Remove outdated `chat.Model` (#178)
+***
+
+* Rename `Gpt_4o_mini` to `Gpt_4o_Mini` to align it with other `chat.Model`s (#182)
+  * Rename `Gpt_4o_mini` to `Gpt_4o_Mini`
+  * Rename `Gpt_4o_mini_2024_07_18` to `Gpt_4o_Mini_2024_07_18`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha12"


### PR DESCRIPTION
# openai4s v0.1.0-alpha12
## [0.1.0-alpha12](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1+closed%3A2024-08-19..2024-09-19) - 2024-09-20

## New Features

* Add `o1-preview` Chat models (#170)
  
  https://platform.openai.com/docs/models/o1
***

* Add `Model.MaxTokens` type for `chat.Model.maxTokens` (#172)
***

* Add `o1-mini` Chat models (#173)

  https://platform.openai.com/docs/models/o1
***

* Add `chatgpt-4o-latest` chat model (#177)

  https://platform.openai.com/docs/models/gpt-4o
***

## Changes

* Remove outdated `chat.Model` (#178)
***

* Rename `Gpt_4o_mini` to `Gpt_4o_Mini` to align it with other `chat.Model`s (#182)
  * Rename `Gpt_4o_mini` to `Gpt_4o_Mini`
  * Rename `Gpt_4o_mini_2024_07_18` to `Gpt_4o_Mini_2024_07_18`
