### PR TITLE
Close #193 - Update GitHub Actions to use `actions/setup-java`'s `sbt` cache and use `sbt/setup-sbt`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,8 @@ jobs:
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: "[Push] Build All for ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: github.event_name == 'push'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,17 +29,8 @@ jobs:
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: "[Push] Build All for ${{ matrix.scala.name }} v${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: github.event_name == 'push'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,17 +29,8 @@ jobs:
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: "[Codecov] Report ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: ${{ matrix.scala.report == 'report' && github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,8 @@ jobs:
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: "[Push] Build All for ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: github.event_name == 'push'
@@ -81,17 +72,8 @@ jobs:
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: "[Codecov] Report ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: ${{ matrix.scala.report == 'report' }}
@@ -124,17 +106,8 @@ jobs:
       with:
         java-version: ${{ env.GH_JAVA_VERSION }}
         distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
-
-    - name: Cache SBT
-      uses: actions/cache@v4.0.2
-      with:
-        path: |
-          ~/.ivy2/cache
-          ~/.cache/coursier
-          ~/.sbt
-        key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-sbt
+        cache: 'sbt'
+    - uses: sbt/setup-sbt@v1
 
     - name: sbt GitHub Release
       env:
@@ -161,18 +134,9 @@ jobs:
         with:
           java-version: ${{ env.GH_JAVA_VERSION }}
           distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
       - uses: olafurpg/setup-gpg@v3
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt
 
       - name: "sbt ci-release - ${{ github.run_number }}"
         if: startsWith(github.ref, 'refs/tags/v')
@@ -211,18 +175,9 @@ jobs:
         with:
           java-version: ${{ env.GH_JAVA_VERSION }}
           distribution: ${{ env.GH_JAVA_DISTRIBUTION }}
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
       - uses: olafurpg/setup-gpg@v3
-
-      - name: Cache SBT
-        uses: actions/cache@v4.0.2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt
 
       - name: "sbt ci-release (no tag) - ${{ github.run_number }}"
         if: startsWith(github.ref, 'refs/heads/')


### PR DESCRIPTION
Close #193 - Update GitHub Actions to use `actions/setup-java`'s `sbt` cache and use `sbt/setup-sbt`