### PR TITLE
openai4s v0.1.0-alpha13

### DIFF
--- a/changelogs/0.1.0-alpha13.md
+++ b/changelogs/0.1.0-alpha13.md
@@ -1,0 +1,20 @@
+## [0.1.0-alpha13](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am1%20closed%3A2024-09-20..2025-02-10) - 2025-02-11
+
+## New Features
+
+* Update `o1` model (#190)
+  * Add `o1` model
+  * Add `o1-2024-12-17` model
+
+* Add `o3-mini` model (#191)
+
+  https://platform.openai.com/docs/models/how-we-use-your-data#o3-mini
+
+    * Add `o3-mini` model
+    * Add `o3-mini-2025-01-31` model
+
+***
+
+## Internal Housekeeping
+
+* Update GitHub Actions to use `actions/setup-java`'s sbt cache and use `sbt/setup-sbt` (#193)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-alpha13"


### PR DESCRIPTION
# openai4s v0.1.0-alpha13
## [0.1.0-alpha13](https://github.com/kevin-lee/openai4s/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am1%20closed%3A2024-09-20..2025-02-10) - 2025-02-11

## New Features

* Update `o1` model (#190)
  * Add `o1` model
  * Add `o1-2024-12-17` model

* Add `o3-mini` model (#191)

  https://platform.openai.com/docs/models/how-we-use-your-data#o3-mini

    * Add `o3-mini` model
    * Add `o3-mini-2025-01-31` model

***

## Internal Housekeeping

* Update GitHub Actions to use `actions/setup-java`'s sbt cache and use `sbt/setup-sbt` (#193)
