### PR TITLE
Update Scala and library versions in build.sbt and sbt plugin versions in plugins.sbt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 3", version: "3.3.1",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 3", version: "3.3.1",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 3", version: "3.3.1",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v5

--- a/build.sbt
+++ b/build.sbt
@@ -33,20 +33,6 @@ ThisBuild / scalafixConfig := (
     ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
 )
 
-ThisBuild / scalafixScalaBinaryVersion := {
-  val log        = sLog.value
-  val newVersion = if (scalaVersion.value.startsWith("3")) {
-    (ThisBuild / scalafixScalaBinaryVersion).value
-  } else {
-    CrossVersion.binaryScalaVersion(scalaVersion.value)
-  }
-
-  log.info(
-    s">> Change ThisBuild / scalafixScalaBinaryVersion from ${(ThisBuild / scalafixScalaBinaryVersion).value} to $newVersion"
-  )
-  newVersion
-}
-
 lazy val openai4s = (project in file("."))
   .enablePlugins(DevOopsGitHubReleasePlugin)
   .settings(
@@ -160,7 +146,7 @@ lazy val props =
     val RepoName       = "openai4s"
 
     val Scala2Versions = List(
-      "2.13.12"
+      "2.13.16"
     )
     val Scala2Version  = Scala2Versions.head
 
@@ -184,41 +170,41 @@ lazy val props =
 
     val IncludeTest = "compile->compile;test->test"
 
-    val HedgehogVersion = "0.10.1"
+    val HedgehogVersion = "0.13.0"
 
-    val HedgehogExtraVersion = "0.7.0"
+    val HedgehogExtraVersion = "0.15.0"
 
-    val CatsVersion = "2.10.0"
+    val CatsVersion = "2.13.0"
 
     val CatsEffect2Version       = "2.4.1"
     val CatsEffect2LatestVersion = "2.5.5"
     val CatsEffect3Version       = "3.5.3"
 
-    val ExtrasVersion = "0.42.0"
+    val ExtrasVersion = "0.49.0"
 
     val NewtypeVersion = "0.4.4"
 
-    val Refined4sVersion = "0.15.0"
+    val Refined4sVersion = "1.10.0"
 
-    val TypeLevelCaseInsensitiveVersion = "1.4.0"
+    val TypeLevelCaseInsensitiveVersion = "1.5.0"
 
     val RefinedVersion = "0.10.1"
 
     val RefinedLatestVersion = "0.11.0"
 
-    val KittensVersion             = "3.0.0"
+    val KittensVersion             = "3.5.0"
     val KittensForScala3_1_Version = "3.0.0-M4"
 
     val Http4sVersion       = "0.22.15"
-    val Http4sLatestVersion = "0.23.23"
+    val Http4sLatestVersion = "0.23.30"
 
-    val PureConfigVersion = "0.17.4"
+    val PureConfigVersion = "0.17.9"
 
     val CirceVersion = "0.14.3"
 
-    val CirceLatestVersion = "0.14.5"
+    val CirceLatestVersion = "0.14.14"
 
-    val LogbackVersion = "1.4.11"
+    val LogbackVersion = "1.5.18"
 
   }
 
@@ -379,14 +365,14 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
       name := prefixedName,
       fork := true,
       semanticdbEnabled := true,
-      semanticdbVersion := scalafixSemanticdb.revision,
       scalafixConfig := (
         if (scalaVersion.value.startsWith("3"))
           ((ThisBuild / baseDirectory).value / ".scalafix-scala3.conf").some
         else
           ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
       ),
-      scalacOptions ++= (if (isScala3(scalaVersion.value)) List.empty else List("-Xsource:3")),
+      scalacOptions ++= (if (isScala3(scalaVersion.value)) List.empty
+                         else List("-Xsource:3", "-Xsource-features:case-apply-copy-access")),
       scalacOptions ~= (_.map {
         case "UTF-8" => "utf8"
         case s => s
@@ -418,6 +404,7 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
 
 lazy val jsSettingsForFuture: SettingsDefinition = List(
   Test / fork := false,
+  coverageEnabled := false,
   Test / scalacOptions ++= (if (scalaVersion.value.startsWith("3")) List.empty
                             else List("-P:scalajs:nowarnGlobalExecutionContext")),
   Test / compile / scalacOptions ++= (if (scalaVersion.value.startsWith("3")) List.empty

--- a/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/ApiUri.scala
+++ b/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/ApiUri.scala
@@ -4,11 +4,10 @@ import cats.{Eq, Show}
 import extras.render.Render
 import extras.render.syntax.*
 import pureconfig.*
-import pureconfig.generic.derivation.default.*
 import refined4s.*
 import refined4s.types.all.*
 import refined4s.modules.cats.derivation.*
-import refined4s.modules.cats.derivation.types.all.given
+
 import refined4s.modules.pureconfig.derivation.PureconfigNewtypeConfigReader
 import refined4s.modules.pureconfig.derivation.types.all.given
 import refined4s.modules.extras.derivation.*

--- a/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/OpenAiConfig.scala
+++ b/modules/openai4s-config/shared/src/main/scala-3/openai4s/config/OpenAiConfig.scala
@@ -2,7 +2,6 @@ package openai4s.config
 
 import cats.{Eq, Show}
 import pureconfig.*
-import pureconfig.generic.derivation.default.*
 import refined4s.types.all.NonEmptyString
 
 /** @author Kevin Lee

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Model.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Model.scala
@@ -7,7 +7,6 @@ import io.circe.{Codec, Decoder, Encoder}
 import refined4s.Newtype
 import refined4s.compat.RefinedCompatAllTypes.*
 import refined4s.modules.cats.derivation.CatsEqShow
-import refined4s.modules.cats.derivation.types.all.given
 import refined4s.modules.circe.derivation.CirceNewtypeCodec
 import refined4s.modules.circe.derivation.types.all.given
 import refined4s.types.all.NonEmptyString
@@ -349,6 +348,7 @@ object Model {
 
   given modelRender: Render[Model] = Render.render(_.toValue)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString")) // FIXME!!!
   given showModel: Show[Model] = {
     case Unsupported(value) =>
       show"Unsupported(value=$value)"

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Response.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/chat/Response.scala
@@ -1,21 +1,19 @@
 package openai4s.types.chat
 
-import cats.{Eq, Show}
 import cats.derived.*
+import cats.{Eq, Show}
 import extras.render.Render
-import io.circe.derivation.{Configuration, ConfiguredCodec, ConfiguredDecoder, ConfiguredEncoder}
 import io.circe.*
+import io.circe.derivation.{Configuration, ConfiguredCodec}
 import openai4s.types
+import openai4s.types.common.*
 import refined4s.*
-import refined4s.types.all.*
 import refined4s.modules.cats.derivation.*
-import refined4s.modules.cats.derivation.types.all.given
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
 import refined4s.modules.extras.derivation.*
 import refined4s.modules.extras.derivation.types.all.given
-
-import openai4s.types.common.*
+import refined4s.types.all.*
 
 import java.time.Instant
 

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/common.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/common.scala
@@ -6,7 +6,7 @@ import io.circe.*
 import openai4s.types
 import refined4s.*
 import refined4s.modules.cats.derivation.*
-import refined4s.modules.cats.derivation.types.all.given
+
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
 import refined4s.modules.extras.derivation.*

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Response.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Response.scala
@@ -10,7 +10,7 @@ import openai4s.types
 import openai4s.types.common.*
 import refined4s.types.all.*
 import refined4s.modules.cats.derivation.*
-import refined4s.modules.cats.derivation.types.all.given
+
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
 import refined4s.modules.extras.derivation.*

--- a/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Text.scala
+++ b/modules/openai4s-core/shared/src/main/scala-3/openai4s/types/completions/Text.scala
@@ -10,7 +10,7 @@ import openai4s.types.common.*
 import refined4s.*
 import refined4s.types.all.*
 import refined4s.modules.cats.derivation.*
-import refined4s.modules.cats.derivation.types.all.given
+
 import refined4s.modules.circe.derivation.*
 import refined4s.modules.circe.derivation.types.all.given
 import refined4s.modules.extras.derivation.*

--- a/modules/openai4s-http4s/shared/src/main/scala/openai4s/http/HttpClient.scala
+++ b/modules/openai4s-http4s/shared/src/main/scala/openai4s/http/HttpClient.scala
@@ -8,8 +8,6 @@ import org.http4s.*
 import org.http4s.Status.Successful as H4sSuccessful
 import org.http4s.client.Client
 
-import scala.annotation.nowarn
-
 /** @author Kevin Lee
   * @since 2023-04-01
   */
@@ -84,13 +82,11 @@ object HttpClient {
   sealed abstract class HttpResponse[F[*]](val response: Response[F])
   object HttpResponse {
 
-    @nowarn("msg=constructor modifiers are assumed by synthetic `(apply|copy)` method")
     final case class Successful[F[*]] private (override val response: Response[F]) extends HttpResponse[F](response)
     object Successful {
       private[HttpResponse] def create[F[*]](response: Response[F]): HttpResponse[F] = new Successful[F](response)
     }
 
-    @nowarn("msg=constructor modifiers are assumed by synthetic `(apply|copy)` method")
     final case class Failed[F[*]] private (override val response: Response[F]) extends HttpResponse[F](response)
     object Failed {
       private[HttpResponse] def create[F[*]](response: Response[F]): HttpResponse[F] = new Failed[F](response)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,24 +1,24 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.5")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.3.0")
 
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.11.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
-addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.1")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.16.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.7.2")
+addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.17.0")
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.13.1")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.16.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-val sbtDevOopsVersion = "3.1.0"
+val sbtDevOopsVersion = "3.2.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)
 
-addSbtPlugin("org.jetbrains.scala" % "sbt-idea-compiler-indices" % "1.0.14")
+addSbtPlugin("org.jetbrains.scala" % "sbt-idea-compiler-indices" % "1.0.16")


### PR DESCRIPTION
Update Scala and library versions in build.sbt and sbt plugin versions in plugins.sbt
- Scala 2.13: `2.13.12` -> `2.13.16`
- `hedgehog`: `0.10.1` -> `0.13.0`
- `hedgehog-extra`: `0.7.0` -> `0.15.0`
- `cats`: `2.10.0` -> `2.13.0`
- `extras`: `0.42.0` -> `0.49.0`
- `refined4s`: `0.15.0` -> `1.10.0`
- TypeLevel `case-insensitive`: `1.4.0` -> `1.5.0`
- `kittens`: `3.0.0` -> `3.5.0`
- `http4s` latest: `0.23.23` -> `0.23.30`
- `pureconfig`: `0.17.4` -> `0.17.9`
- `circe` latest: `0.14.5` -> `0.14.14`
- `logback`: `1.4.11` -> `1.5.18`

- `sbt-ci-release`: `1.5.12` -> `1.11.1`
- `sbt-wartremover`: `3.1.5` -> `3.3.0`
- `sbt-scalafix`: `0.11.1` -> `0.14.3`
- `sbt-scalafmt`: `2.5.2` -> `2.5.5`
- `sbt-scoverage`: `2.0.9` -> `2.3.0`
- `sbt-scalajs`: `1.13.1` -> `1.16.0`
- `sbt-scalajs-crossproject`: `1.2.0` -> `1.3.2`
- `sbt-mdoc`: `2.5.1` -> `2.7.2`
- `sbt-devoops`: `3.1.0` -> `3.2.1`
- `sbt-docusaur`: `0.16.0` -> `0.17.0`
- `sbt-idea-compiler-indices`: `1.0.14` -> `1.0.16`

Code cleanup:
- Remove unused imports from Scala 3 files
- Remove unused `pureconfig.generic.derivation.default.*` import
- Remove unused `refined4s.modules.cats.derivation.types.all.given` imports
- Remove unused `scala.annotation.nowarn` import
- Add WartRemover suppression for `toString` usage in `Model`

Add `coverageEnabled := false` to Scala.js settings