### PR TITLE
openai4s v0.1.0-alpha14

### DIFF
--- a/changelogs/0.1.0-alpha14.md
+++ b/changelogs/0.1.0-alpha14.md
@@ -1,0 +1,40 @@
+## [0.1.0-alpha14](https://github.com/kevin-lee/openai4s/issues?q=is%3Aclosed%20milestone%3Am1%20closed%3A2025-02-11..2025-09-23) - 2025-09-23
+
+
+## Internal Housekeeping
+
+* Update Scala and library versions in `build.sbt` and sbt plugin versions in `plugins.sbt` (#203)
+
+  - Scala 2.13: `2.13.12` -> `2.13.16`
+  - `hedgehog`: `0.10.1` -> `0.13.0`
+  - `hedgehog-extra`: `0.7.0` -> `0.15.0`
+  - `cats`: `2.10.0` -> `2.13.0`
+  - `extras`: `0.42.0` -> `0.49.0`
+  - `refined4s`: `0.15.0` -> `1.10.0`
+  - TypeLevel `case-insensitive`: `1.4.0` -> `1.5.0`
+  - `kittens`: `3.0.0` -> `3.5.0`
+  - `http4s` latest: `0.23.23` -> `0.23.30`
+  - `pureconfig`: `0.17.4` -> `0.17.9`
+  - `circe` latest: `0.14.5` -> `0.14.14`
+  - `logback`: `1.4.11` -> `1.5.18`
+  
+  - `sbt-ci-release`: `1.5.12` -> `1.11.1`
+  - `sbt-wartremover`: `3.1.5` -> `3.3.0`
+  - `sbt-scalafix`: `0.11.1` -> `0.14.3`
+  - `sbt-scalafmt`: `2.5.2` -> `2.5.5`
+  - `sbt-scoverage`: `2.0.9` -> `2.3.0`
+  - `sbt-scalajs`: `1.13.1` -> `1.16.0`
+  - `sbt-scalajs-crossproject`: `1.2.0` -> `1.3.2`
+  - `sbt-mdoc`: `2.5.1` -> `2.7.2`
+  - `sbt-devoops`: `3.1.0` -> `3.2.1`
+  - `sbt-docusaur`: `0.16.0` -> `0.17.0`
+  - `sbt-idea-compiler-indices`: `1.0.14` -> `1.0.16`
+
+  Code cleanup:
+  - Remove unused imports from Scala 3 files
+  - Remove unused `pureconfig.generic.derivation.default.*` import
+  - Remove unused `refined4s.modules.cats.derivation.types.all.given` imports
+  - Remove unused `scala.annotation.nowarn` import
+  - Add WartRemover suppression for `toString` usage in `Model`
+  
+  Add `coverageEnabled := false` to Scala.js settings


### PR DESCRIPTION
# openai4s v0.1.0-alpha14
## [0.1.0-alpha14](https://github.com/kevin-lee/openai4s/issues?q=is%3Aclosed%20milestone%3Am1%20closed%3A2025-02-11..2025-09-23) - 2025-09-23


## Internal Housekeeping

* Update Scala and library versions in `build.sbt` and sbt plugin versions in `plugins.sbt` (#203)

  - Scala 2.13: `2.13.12` -> `2.13.16`
  - `hedgehog`: `0.10.1` -> `0.13.0`
  - `hedgehog-extra`: `0.7.0` -> `0.15.0`
  - `cats`: `2.10.0` -> `2.13.0`
  - `extras`: `0.42.0` -> `0.49.0`
  - `refined4s`: `0.15.0` -> `1.10.0`
  - TypeLevel `case-insensitive`: `1.4.0` -> `1.5.0`
  - `kittens`: `3.0.0` -> `3.5.0`
  - `http4s` latest: `0.23.23` -> `0.23.30`
  - `pureconfig`: `0.17.4` -> `0.17.9`
  - `circe` latest: `0.14.5` -> `0.14.14`
  - `logback`: `1.4.11` -> `1.5.18`
  
  - `sbt-ci-release`: `1.5.12` -> `1.11.1`
  - `sbt-wartremover`: `3.1.5` -> `3.3.0`
  - `sbt-scalafix`: `0.11.1` -> `0.14.3`
  - `sbt-scalafmt`: `2.5.2` -> `2.5.5`
  - `sbt-scoverage`: `2.0.9` -> `2.3.0`
  - `sbt-scalajs`: `1.13.1` -> `1.16.0`
  - `sbt-scalajs-crossproject`: `1.2.0` -> `1.3.2`
  - `sbt-mdoc`: `2.5.1` -> `2.7.2`
  - `sbt-devoops`: `3.1.0` -> `3.2.1`
  - `sbt-docusaur`: `0.16.0` -> `0.17.0`
  - `sbt-idea-compiler-indices`: `1.0.14` -> `1.0.16`

  Code cleanup:
  - Remove unused imports from Scala 3 files
  - Remove unused `pureconfig.generic.derivation.default.*` import
  - Remove unused `refined4s.modules.cats.derivation.types.all.given` imports
  - Remove unused `scala.annotation.nowarn` import
  - Add WartRemover suppression for `toString` usage in `Model`
  
  Add `coverageEnabled := false` to Scala.js settings
