### PR TITLE
openai4s v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,371 @@
+## [0.1.0](https://github.com/kevin-lee/openai4s/issues?q=is%3Aclosed%20milestone%3Am1) - 2025-11-14
+
+
+## New Features
+
+* Add support for GPT-4 Turbo models (#101)
+
+  OpenAI announced a public release of GPT-4 and GPT-4 Turbo a few days ago.
+    * `gpt-4-1106-preview`
+    * `gpt-4-vision-preview`
+
+  The turbo models have a context length of 128,000 tokens, so it's worth having them soon.
+
+
+* Update `GPT-4` and `GPT-4 Turbo` models (#139)
+
+  Update the current Chat models with the models from [GPT-4 and GPT-4 Turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo).
+    * `gpt-4-0125-preview`
+    * `gpt-4-turbo-preview`
+    * `gpt-4-1106-vision-preview`
+
+* Add `description`, `maxTokens` and `trainingData` to `Model` for `Chat` (#142)
+
+* Update `GPT-3.5` Turbo models (#147)
+
+  GPT-3.5 Turbo ([📄](https://platform.openai.com/docs/models/gpt-3-5-turbo))
+
+  Add the following models
+    * `gpt-3.5-turbo-0125`
+    * `gpt-3.5-turbo-1106`
+    * `gpt-3.5-turbo-instruct`
+
+* Add `GPT-4o` models (#154)
+
+  Add the Chat models from [GPT-4o](https://platform.openai.com/docs/models/gpt-4o).
+    * `gpt-4o`
+    * `gpt-4o-2024-05-13`
+
+* Update `GPT-4` and `GPT-4` Turbo models (#156)
+
+  Update the current Chat models with the models from [GPT-4 Turbo and GPT-4](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4).
+
+
+
+* Add [`GPT-4o mini`](https://platform.openai.com/docs/models/gpt-4o-mini) models (#167)
+
+  Thanks @keuhdall
+
+***
+
+* Add `o1-preview` Chat models (#170)
+
+  https://platform.openai.com/docs/models/o1
+***
+
+* Add `Model.MaxTokens` type for `chat.Model.maxTokens` (#172)
+***
+
+* Add `o1-mini` Chat models (#173)
+
+  https://platform.openai.com/docs/models/o1
+***
+
+* Add `chatgpt-4o-latest` chat model (#177)
+
+  https://platform.openai.com/docs/models/gpt-4o
+***
+
+
+* Update `o1` model (#190)
+    * Add `o1` model
+    * Add `o1-2024-12-17` model
+
+* Add `o3-mini` model (#191)
+
+  https://platform.openai.com/docs/models/how-we-use-your-data#o3-mini
+
+    * Add `o3-mini` model
+    * Add `o3-mini-2025-01-31` model
+
+
+* Add `GPT-5` models (#205)
+
+  https://platform.openai.com/docs/models/gpt-5
+
+* Add `gpt-5-pro` model (#207)
+
+  https://platform.openai.com/docs/models/gpt-5-pro
+
+* Replace `Unsupported` with `UserInput` to accept unlisted models in openai4s (#209)
+  ```scala
+  Model.userInput(
+    NonEmptyString("gpt-5-pro-2025-10-06"),
+  )
+  // Model = Model.UserInput(
+  //   value = "gpt-5-pro-2025-10-06",
+  //   description = "",
+  //   maxTokens = Model.MaxTokens(PosInt(1)),
+  //   maxOutputTokens = Model.MaxOutputTokens(PosInt(1)),
+  //   trainingData = None,
+  // )
+  ```
+
+* Add test for `Show[Model]` to validate string representation (#213)
+
+***
+
+
+## Done
+* Set up the project (#1)
+* Drop supporting Scala 2.12 (#20)
+* Add `api` sub-project and add `chat/completions` (#26)
+* Support Scala 3 (#29)
+  
+  Support Scala 3.2.2. There might be an issue with newtype and refined in Scala 3 as
+  * newtype doesn't support Scala 3
+  * Some refined features are broken in Scala 3 (e.g. macro for compile-time type check)
+* Add `completions.Text` (#34)
+  * https://platform.openai.com/docs/api-reference/completions#:~:text=prompt%20and%20parameters.-,Request%20body,-model
+* Add `completions.Response` (#37)
+  * https://platform.openai.com/docs/api-reference/completions/create#:~:text=%22%5Cn%22%0A%7D-,Response
+* Add `CompletionsApi` (#40)
+  ```scala
+  import openai4s.types.completions
+  
+  val completionsApi = CompletionsApi[F](completionsUri, apiKey, httpClient)
+  val text = completions.Text(
+    model = completions.Model.text_Davinci_003,
+    prompt = completions.Text.Prompt(NonEmptyString("What is tagless final?")).some,
+    maxTokens = completions.Text.MaxTokens(PosInt(2048)).some,
+    temperature = completions.Text.Temperature.unsafeFrom(0.2f).some,
+    topP = none,
+    n = none,
+    stream = none,
+    logprobs = none,
+    stop = none,
+  )
+  completionsApi.completions(text)
+  ```
+
+***
+
+
+## Fixed
+* Compile-time validation of `Uri.apply` doesn't work in Scala 3 (#54)
+
+
+***
+
+## Added
+* Add `Show[HttpError[F]]` type-class instance for Scala 3 (#79)
+* Update available ChatGPT models - GPT 4 models with 32k tokens are not available yet (#80)
+
+  More about the models can be found at the following links.
+  * [Model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility)
+  * [GPT-4](https://platform.openai.com/docs/models/gpt-4)
+  * [GPT-3.5](https://platform.openai.com/docs/models/gpt-3-5)
+  
+  > NOTE: GPT 4 Models with 32k tokens (context length) are not available yet.
+  > Reference: [https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4](https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4)
+
+***
+
+## Improvement
+
+* Simplify creation of `openai4s.types.chat.Response.Choice.Message` (#95)
+
+  Instead of
+  ```scala
+  import openai4s.types
+  import openai4s.types.chat.*
+  
+  Response.Choice.Message(
+    types.Message(
+      types.Message.Role("assistant"),
+      types.Message.Content("content value")
+    )
+  )
+  ```
+  it could be
+  ```scala
+  import openai4s.types
+  import openai4s.types.chat.*
+  
+  Response.Choice.Message(
+    types.Message.Role("assistant"),
+    types.Message.Content("content value")
+  )
+  ```
+
+* Add experimental syntax for `NonEmptyString` in Scala 3 (#97)
+***
+
+
+
+## Changed
+* Simplify some text types (#53)
+* Add the default Open AI API `Uri` (`ApiUri`) (#57)
+  ```scala
+  ApiUri.default: ApiUri // ApiUri with https://api.openai.com
+  ```
+* Simplify creation of `openai4s.types.chat.Chat.Message` (#60)
+
+  Instead of
+  ```scala
+  import openai4s.types.chat
+  import openai4s.types
+  
+  chat.Chat.Message(
+    types.Message(
+      Message.Role("user"),
+      Message.Content("blah blah"),
+    )
+  )
+  ```
+  it can be
+  ```scala
+  import openai4s.types.chat
+  
+  chat.Chat.Message(
+    Message.Role("user"),
+    Message.Content("blah blah"),
+  )
+  ```
+* Add `ApiCore` to share `HttpClient` and `ApiKey` (#62)
+* Add smart constructors for newtypes in Scala 3 to simplify newtype creation (#64)
+
+  With the current `Newtype` in Scala 3 (openai4s's newtype support for Scala 3), the code looks like this
+  ```scala 3
+  type MaxTokens = MaxTokens.Type
+  object MaxTokens extends Newtype[PosInt]
+  
+  MaxTokens(PosInt(123)) // valid
+  MaxTokens(PosInt(-123)) // compile-time error
+  ```
+  In Scala 2, it could be simplified by importing `eu.timepit.refined.auto.*`.
+
+  e.g.) In Scala 2,
+  ```scala
+  import eu.timepit.refined.auto.*
+  
+  MaxTokens(123) // valid
+  MaxTokens(-123) // compile-time error
+  ```
+  ***
+  Now in Scala, it could be something similar.
+  ```scala 3
+  type MaxTokens = MaxTokens.Type
+  object MaxTokens extends Newtype[PosInt] {
+    inline def apply(inline token: Int): MaxTokens
+  }
+  ```
+  then it could be simplified like
+  ```scala
+  MaxTokens(PosInt(123)) // valid
+  MaxTokens(PosInt(-123)) // compile-time error
+  
+  MaxTokens(123) // valid
+  MaxTokens(-123) // compile-time error
+  ```
+***
+
+* Add body to an error from `HttpClient` (#76)
+
+  `UnexpectedStatus(status: Status, requestMethod: Method, requestUri: Uri)`
+
+  to
+
+  `UnexpectedStatus[F[*]](request: Request[F], status: Status, body: Option[String])`
+***
+* Update `UnexpectedStatus` to handle more response body cases (#88)
+
+  `UnexpectedStatus` had `request: Request[F], status: Status, body: Option[String]`.
+
+  From 0.1.0-alpha5, it is changed to have one of
+    * `Json`
+    * `String`
+    * any exception that might be thrown while getting the above type values.
+
+  for `body` instead of having optional `String` (`Option[String]`).
+***
+* Re-organize data model (#106)
+
+  The following data types are now shared
+  * `Message` used for `Chat` and `Response.Choice`
+  * `Temperature` and `MaxTokens` for `Chat` and `Text`
+  * `Index` and `FinishReason` for `Response` for `Chat` and `Text`
+***
+* Replace custom newtypes and refinement types with `refined4s` (#112)
+* Replace more types for Scala 3 with `refined4s`'s (#118)
+
+* Remove deprecated models (#141)
+
+* Remove outdated `chat.Model` (#178)
+
+* Rename `Gpt_4o_mini` to `Gpt_4o_Mini` to align it with other `chat.Model`s (#182)
+  * Rename `Gpt_4o_mini` to `Gpt_4o_Mini`
+  * Rename `Gpt_4o_mini_2024_07_18` to `Gpt_4o_Mini_2024_07_18`
+
+***
+
+
+## Internal Housekeeping
+
+* Upgrade Scala, sbt and sbt plugins (#103)
+    * Scala 2 to `2.13.12`
+    * Scala 3 to `3.3.1`
+    * sbt to `1.9.7`
+    * `sbt-wartremover` to `3.1.5`
+    * `sbt-tpolecat` to `0.5.0`
+    * `sbt-scalafix` to `0.11.1`
+    * `sbt-scalafmt` to `2.5.2`
+    * `sbt-scoverage` to `2.0.9`
+    * `sbt-mdoc` to `2.5.1`
+
+* Upgrade `refined4s` to ~~`0.8.0`~~ `0.11.0` (#116)
+* Use more derived type-classes and `hedgehog-extra-refined4s` (#120)
+    * Use Scala 3 `derives` syntax and also use more type-class instances from Kittens.
+    * Use `hedgehog-extra-refined4s` and its pre-defined `Gen`s for refined4s
+
+* Use `refined4s-refined-compat` modules (#125)
+
+* Bump `cats-effect` 3 to `3.5.3` (#129)
+
+* Bump `hedgehog-extra` to `0.7.0` (#130)
+
+* Bump `refined4s` to `0.15.0` (#150)
+
+* Remove unused `refined4s-doobie` from `libraryDependencies` (#164)
+
+* Update GitHub Actions to use `actions/setup-java`'s sbt cache and use `sbt/setup-sbt` (#193)
+
+* Update Scala and library versions in `build.sbt` and sbt plugin versions in `plugins.sbt` (#203)
+
+    - Scala 2.13: `2.13.12` -> `2.13.16`
+    - `hedgehog`: `0.10.1` -> `0.13.0`
+    - `hedgehog-extra`: `0.7.0` -> `0.15.0`
+    - `cats`: `2.10.0` -> `2.13.0`
+    - `extras`: `0.42.0` -> `0.49.0`
+    - `refined4s`: `0.15.0` -> `1.10.0`
+    - TypeLevel `case-insensitive`: `1.4.0` -> `1.5.0`
+    - `kittens`: `3.0.0` -> `3.5.0`
+    - `http4s` latest: `0.23.23` -> `0.23.30`
+    - `pureconfig`: `0.17.4` -> `0.17.9`
+    - `circe` latest: `0.14.5` -> `0.14.14`
+    - `logback`: `1.4.11` -> `1.5.18`
+
+    - `sbt-ci-release`: `1.5.12` -> `1.11.1`
+    - `sbt-wartremover`: `3.1.5` -> `3.3.0`
+    - `sbt-scalafix`: `0.11.1` -> `0.14.3`
+    - `sbt-scalafmt`: `2.5.2` -> `2.5.5`
+    - `sbt-scoverage`: `2.0.9` -> `2.3.0`
+    - `sbt-scalajs`: `1.13.1` -> `1.16.0`
+    - `sbt-scalajs-crossproject`: `1.2.0` -> `1.3.2`
+    - `sbt-mdoc`: `2.5.1` -> `2.7.2`
+    - `sbt-devoops`: `3.1.0` -> `3.2.1`
+    - `sbt-docusaur`: `0.16.0` -> `0.17.0`
+    - `sbt-idea-compiler-indices`: `1.0.14` -> `1.0.16`
+
+  Code cleanup:
+    - Remove unused imports from Scala 3 files
+    - Remove unused `pureconfig.generic.derivation.default.*` import
+    - Remove unused `refined4s.modules.cats.derivation.types.all.given` imports
+    - Remove unused `scala.annotation.nowarn` import
+    - Add WartRemover suppression for `toString` usage in `Model`
+
+  Add `coverageEnabled := false` to Scala.js settings
+
+* Update: `build.properties` - bump sbt to `1.11.7` (#210)
+
+* Update: `refined4s`: 1.10.0 -> 1.13.0 (#211)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
# openai4s v0.1.0
## [0.1.0](https://github.com/kevin-lee/openai4s/issues?q=is%3Aclosed%20milestone%3Am1) - 2025-11-14


## New Features

* Add support for GPT-4 Turbo models (#101)

  OpenAI announced a public release of GPT-4 and GPT-4 Turbo a few days ago.
    * `gpt-4-1106-preview`
    * `gpt-4-vision-preview`

  The turbo models have a context length of 128,000 tokens, so it's worth having them soon.


* Update `GPT-4` and `GPT-4 Turbo` models (#139)

  Update the current Chat models with the models from [GPT-4 and GPT-4 Turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo).
    * `gpt-4-0125-preview`
    * `gpt-4-turbo-preview`
    * `gpt-4-1106-vision-preview`

* Add `description`, `maxTokens` and `trainingData` to `Model` for `Chat` (#142)

* Update `GPT-3.5` Turbo models (#147)

  GPT-3.5 Turbo ([📄](https://platform.openai.com/docs/models/gpt-3-5-turbo))

  Add the following models
    * `gpt-3.5-turbo-0125`
    * `gpt-3.5-turbo-1106`
    * `gpt-3.5-turbo-instruct`

* Add `GPT-4o` models (#154)

  Add the Chat models from [GPT-4o](https://platform.openai.com/docs/models/gpt-4o).
    * `gpt-4o`
    * `gpt-4o-2024-05-13`

* Update `GPT-4` and `GPT-4` Turbo models (#156)

  Update the current Chat models with the models from [GPT-4 Turbo and GPT-4](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4).



* Add [`GPT-4o mini`](https://platform.openai.com/docs/models/gpt-4o-mini) models (#167)

  Thanks @keuhdall

***

* Add `o1-preview` Chat models (#170)

  https://platform.openai.com/docs/models/o1
***

* Add `Model.MaxTokens` type for `chat.Model.maxTokens` (#172)
***

* Add `o1-mini` Chat models (#173)

  https://platform.openai.com/docs/models/o1
***

* Add `chatgpt-4o-latest` chat model (#177)

  https://platform.openai.com/docs/models/gpt-4o
***


* Update `o1` model (#190)
    * Add `o1` model
    * Add `o1-2024-12-17` model

* Add `o3-mini` model (#191)

  https://platform.openai.com/docs/models/how-we-use-your-data#o3-mini

    * Add `o3-mini` model
    * Add `o3-mini-2025-01-31` model


* Add `GPT-5` models (#205)

  https://platform.openai.com/docs/models/gpt-5

* Add `gpt-5-pro` model (#207)

  https://platform.openai.com/docs/models/gpt-5-pro

* Replace `Unsupported` with `UserInput` to accept unlisted models in openai4s (#209)
  ```scala
  Model.userInput(
    NonEmptyString("gpt-5-pro-2025-10-06"),
  )
  // Model = Model.UserInput(
  //   value = "gpt-5-pro-2025-10-06",
  //   description = "",
  //   maxTokens = Model.MaxTokens(PosInt(1)),
  //   maxOutputTokens = Model.MaxOutputTokens(PosInt(1)),
  //   trainingData = None,
  // )
  ```

* Add test for `Show[Model]` to validate string representation (#213)

***


## Done
* Set up the project (#1)
* Drop supporting Scala 2.12 (#20)
* Add `api` sub-project and add `chat/completions` (#26)
* Support Scala 3 (#29)
  
  Support Scala 3.2.2. There might be an issue with newtype and refined in Scala 3 as
  * newtype doesn't support Scala 3
  * Some refined features are broken in Scala 3 (e.g. macro for compile-time type check)
* Add `completions.Text` (#34)
  * https://platform.openai.com/docs/api-reference/completions#:~:text=prompt%20and%20parameters.-,Request%20body,-model
* Add `completions.Response` (#37)
  * https://platform.openai.com/docs/api-reference/completions/create#:~:text=%22%5Cn%22%0A%7D-,Response
* Add `CompletionsApi` (#40)
  ```scala
  import openai4s.types.completions
  
  val completionsApi = CompletionsApi[F](completionsUri, apiKey, httpClient)
  val text = completions.Text(
    model = completions.Model.text_Davinci_003,
    prompt = completions.Text.Prompt(NonEmptyString("What is tagless final?")).some,
    maxTokens = completions.Text.MaxTokens(PosInt(2048)).some,
    temperature = completions.Text.Temperature.unsafeFrom(0.2f).some,
    topP = none,
    n = none,
    stream = none,
    logprobs = none,
    stop = none,
  )
  completionsApi.completions(text)
  ```

***


## Fixed
* Compile-time validation of `Uri.apply` doesn't work in Scala 3 (#54)


***

## Added
* Add `Show[HttpError[F]]` type-class instance for Scala 3 (#79)
* Update available ChatGPT models - GPT 4 models with 32k tokens are not available yet (#80)

  More about the models can be found at the following links.
  * [Model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility)
  * [GPT-4](https://platform.openai.com/docs/models/gpt-4)
  * [GPT-3.5](https://platform.openai.com/docs/models/gpt-3-5)
  
  > NOTE: GPT 4 Models with 32k tokens (context length) are not available yet.
  > Reference: [https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4](https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4)

***

## Improvement

* Simplify creation of `openai4s.types.chat.Response.Choice.Message` (#95)

  Instead of
  ```scala
  import openai4s.types
  import openai4s.types.chat.*
  
  Response.Choice.Message(
    types.Message(
      types.Message.Role("assistant"),
      types.Message.Content("content value")
    )
  )
  ```
  it could be
  ```scala
  import openai4s.types
  import openai4s.types.chat.*
  
  Response.Choice.Message(
    types.Message.Role("assistant"),
    types.Message.Content("content value")
  )
  ```

* Add experimental syntax for `NonEmptyString` in Scala 3 (#97)
***



## Changed
* Simplify some text types (#53)
* Add the default Open AI API `Uri` (`ApiUri`) (#57)
  ```scala
  ApiUri.default: ApiUri // ApiUri with https://api.openai.com
  ```
* Simplify creation of `openai4s.types.chat.Chat.Message` (#60)

  Instead of
  ```scala
  import openai4s.types.chat
  import openai4s.types
  
  chat.Chat.Message(
    types.Message(
      Message.Role("user"),
      Message.Content("blah blah"),
    )
  )
  ```
  it can be
  ```scala
  import openai4s.types.chat
  
  chat.Chat.Message(
    Message.Role("user"),
    Message.Content("blah blah"),
  )
  ```
* Add `ApiCore` to share `HttpClient` and `ApiKey` (#62)
* Add smart constructors for newtypes in Scala 3 to simplify newtype creation (#64)

  With the current `Newtype` in Scala 3 (openai4s's newtype support for Scala 3), the code looks like this
  ```scala 3
  type MaxTokens = MaxTokens.Type
  object MaxTokens extends Newtype[PosInt]
  
  MaxTokens(PosInt(123)) // valid
  MaxTokens(PosInt(-123)) // compile-time error
  ```
  In Scala 2, it could be simplified by importing `eu.timepit.refined.auto.*`.

  e.g.) In Scala 2,
  ```scala
  import eu.timepit.refined.auto.*
  
  MaxTokens(123) // valid
  MaxTokens(-123) // compile-time error
  ```
  ***
  Now in Scala, it could be something similar.
  ```scala 3
  type MaxTokens = MaxTokens.Type
  object MaxTokens extends Newtype[PosInt] {
    inline def apply(inline token: Int): MaxTokens
  }
  ```
  then it could be simplified like
  ```scala
  MaxTokens(PosInt(123)) // valid
  MaxTokens(PosInt(-123)) // compile-time error
  
  MaxTokens(123) // valid
  MaxTokens(-123) // compile-time error
  ```
***

* Add body to an error from `HttpClient` (#76)

  `UnexpectedStatus(status: Status, requestMethod: Method, requestUri: Uri)`

  to

  `UnexpectedStatus[F[*]](request: Request[F], status: Status, body: Option[String])`
***
* Update `UnexpectedStatus` to handle more response body cases (#88)

  `UnexpectedStatus` had `request: Request[F], status: Status, body: Option[String]`.

  From 0.1.0-alpha5, it is changed to have one of
    * `Json`
    * `String`
    * any exception that might be thrown while getting the above type values.

  for `body` instead of having optional `String` (`Option[String]`).
***
* Re-organize data model (#106)

  The following data types are now shared
  * `Message` used for `Chat` and `Response.Choice`
  * `Temperature` and `MaxTokens` for `Chat` and `Text`
  * `Index` and `FinishReason` for `Response` for `Chat` and `Text`
***
* Replace custom newtypes and refinement types with `refined4s` (#112)
* Replace more types for Scala 3 with `refined4s`'s (#118)

* Remove deprecated models (#141)

* Remove outdated `chat.Model` (#178)

* Rename `Gpt_4o_mini` to `Gpt_4o_Mini` to align it with other `chat.Model`s (#182)
  * Rename `Gpt_4o_mini` to `Gpt_4o_Mini`
  * Rename `Gpt_4o_mini_2024_07_18` to `Gpt_4o_Mini_2024_07_18`

***


## Internal Housekeeping

* Upgrade Scala, sbt and sbt plugins (#103)
    * Scala 2 to `2.13.12`
    * Scala 3 to `3.3.1`
    * sbt to `1.9.7`
    * `sbt-wartremover` to `3.1.5`
    * `sbt-tpolecat` to `0.5.0`
    * `sbt-scalafix` to `0.11.1`
    * `sbt-scalafmt` to `2.5.2`
    * `sbt-scoverage` to `2.0.9`
    * `sbt-mdoc` to `2.5.1`

* Upgrade `refined4s` to ~~`0.8.0`~~ `0.11.0` (#116)
* Use more derived type-classes and `hedgehog-extra-refined4s` (#120)
    * Use Scala 3 `derives` syntax and also use more type-class instances from Kittens.
    * Use `hedgehog-extra-refined4s` and its pre-defined `Gen`s for refined4s

* Use `refined4s-refined-compat` modules (#125)

* Bump `cats-effect` 3 to `3.5.3` (#129)

* Bump `hedgehog-extra` to `0.7.0` (#130)

* Bump `refined4s` to `0.15.0` (#150)

* Remove unused `refined4s-doobie` from `libraryDependencies` (#164)

* Update GitHub Actions to use `actions/setup-java`'s sbt cache and use `sbt/setup-sbt` (#193)

* Update Scala and library versions in `build.sbt` and sbt plugin versions in `plugins.sbt` (#203)

    - Scala 2.13: `2.13.12` -> `2.13.16`
    - `hedgehog`: `0.10.1` -> `0.13.0`
    - `hedgehog-extra`: `0.7.0` -> `0.15.0`
    - `cats`: `2.10.0` -> `2.13.0`
    - `extras`: `0.42.0` -> `0.49.0`
    - `refined4s`: `0.15.0` -> `1.10.0`
    - TypeLevel `case-insensitive`: `1.4.0` -> `1.5.0`
    - `kittens`: `3.0.0` -> `3.5.0`
    - `http4s` latest: `0.23.23` -> `0.23.30`
    - `pureconfig`: `0.17.4` -> `0.17.9`
    - `circe` latest: `0.14.5` -> `0.14.14`
    - `logback`: `1.4.11` -> `1.5.18`

    - `sbt-ci-release`: `1.5.12` -> `1.11.1`
    - `sbt-wartremover`: `3.1.5` -> `3.3.0`
    - `sbt-scalafix`: `0.11.1` -> `0.14.3`
    - `sbt-scalafmt`: `2.5.2` -> `2.5.5`
    - `sbt-scoverage`: `2.0.9` -> `2.3.0`
    - `sbt-scalajs`: `1.13.1` -> `1.16.0`
    - `sbt-scalajs-crossproject`: `1.2.0` -> `1.3.2`
    - `sbt-mdoc`: `2.5.1` -> `2.7.2`
    - `sbt-devoops`: `3.1.0` -> `3.2.1`
    - `sbt-docusaur`: `0.16.0` -> `0.17.0`
    - `sbt-idea-compiler-indices`: `1.0.14` -> `1.0.16`

  Code cleanup:
    - Remove unused imports from Scala 3 files
    - Remove unused `pureconfig.generic.derivation.default.*` import
    - Remove unused `refined4s.modules.cats.derivation.types.all.given` imports
    - Remove unused `scala.annotation.nowarn` import
    - Add WartRemover suppression for `toString` usage in `Model`

  Add `coverageEnabled := false` to Scala.js settings

* Update: `build.properties` - bump sbt to `1.11.7` (#210)

* Update: `refined4s`: 1.10.0 -> 1.13.0 (#211)
